### PR TITLE
fix(connector): add timeouts to kill the http connection

### DIFF
--- a/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
@@ -99,6 +99,8 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
     private static final int HTTP_PROTOCOL_VERSION_MINOR = 1;
     private static final int CONNECTION_TIMEOUT = 60000;
 
+    private static int SOCKET_TIMEOUT = 60000;
+
     /**
      * The class logger
      */
@@ -459,6 +461,9 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
             final Builder requestConfigurationBuilder = RequestConfig.custom();
             requestConfigurationBuilder.setConnectionRequestTimeout(CONNECTION_TIMEOUT);
             requestConfigurationBuilder.setRedirectsEnabled(request.isRedirect());
+            requestConfigurationBuilder.setConnectTimeout(CONNECTION_TIMEOUT);
+            requestConfigurationBuilder.setSocketTimeout(SOCKET_TIMEOUT);
+
 
             final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
             httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
@@ -772,4 +777,15 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
         }
         LOGGER.fine("executeBusinessLogic error: " + stringBuffer.toString());
     }
+
+    //for tests purpose only
+    protected static int getSocketTimeout() {
+        return SOCKET_TIMEOUT;
+    }
+
+    //for tests purpose only
+    protected static void setSocketTimeout(int socketTimeout) {
+        SOCKET_TIMEOUT = socketTimeout;
+    }
+
 }

--- a/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
@@ -342,6 +342,7 @@ public class RESTConnectorTest extends AcceptanceTestBase {
         rest.setAPIAccessor(getApiAccessor());
         rest.setInputParameters(parameters);
         rest.validateInputParameters();
+        rest.setSocketTimeout(10000);
         return rest.execute();
     }
 
@@ -455,6 +456,15 @@ public class RESTConnectorTest extends AcceptanceTestBase {
         assertEquals(((Map<String, Object>) ((List) bodyAsMap).get(0)).get("name"), "Romain");
     }
 
+    @Test
+    public void should_kill_connection_after_timeout() throws BonitaException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withFixedDelay(100000).withStatus(HttpStatus.SC_OK).withBody("").withHeader(WM_CONTENT_TYPE, JSON)));
+
+        thrown.expect(ConnectorException.class);
+        executeConnector(buildContentTypeParametersSet(JSON));
+    }
     /**
      * Test the fake content type
      * @throws BonitaException exception


### PR DESCRIPTION
httpClient.execute() doesn't respond to the interrupt flag. As such the only (and recommended in the doc) way to kill its thread is a timeout.

Closes [BS-16960](https://bonitasoft.atlassian.net/browse/BS-16960)