### PR TITLE
fix #42 (RESTConnector) : json simple value causes exception

### DIFF
--- a/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
@@ -412,8 +412,15 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
                         if (contentType != null
                                 && !Strings.isNullOrEmpty(contentType.getValue())
                                 && contentType.getValue().toLowerCase().contains("json")) {
-                            setBody(new ObjectMapper().readValue(bodyResponse,
-                                    bodyResponse.startsWith("[") ? List.class : HashMap.class));
+                            if (bodyResponse.startsWith("[")) {
+                                setBody(new ObjectMapper().readValue(bodyResponse, List.class));
+                            } else if(bodyResponse.startsWith("{")) {
+                                setBody(new ObjectMapper().readValue(bodyResponse, HashMap.class));
+                            } else { 
+                                LOGGER.warning(String.format(
+                                    "Body as map output cannot be set. Response content is not valid json(%s).",
+                                    bodyResponse));
+                            }
                         } else {
                             LOGGER.warning(String.format(
                                     "Body as map output cannot be set. Response content type is not json compliant(%s).",

--- a/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
@@ -83,6 +83,8 @@ import org.bonitasoft.connectors.rest.model.Store;
 import org.bonitasoft.engine.connector.ConnectorException;
 import org.bonitasoft.engine.connector.ConnectorValidationException;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 
@@ -412,13 +414,17 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
                         if (contentType != null
                                 && !Strings.isNullOrEmpty(contentType.getValue())
                                 && contentType.getValue().toLowerCase().contains("json")) {
-                            if (bodyResponse.startsWith("[")) {
-                                setBody(new ObjectMapper().readValue(bodyResponse, List.class));
-                            } else if(bodyResponse.startsWith("{")) {
-                                setBody(new ObjectMapper().readValue(bodyResponse, HashMap.class));
-                            } else { 
+                            try {
+                                if (bodyResponse.startsWith("[")) {
+                                    setBody(new ObjectMapper().readValue(bodyResponse, List.class));
+                                } else if(bodyResponse.startsWith("{")) {
+                                    setBody(new ObjectMapper().readValue(bodyResponse, HashMap.class));
+                                } else { 
+                                        setBody(new ObjectMapper().readValue(bodyResponse, Object.class));
+                                }
+                            } catch (JsonParseException | JsonMappingException e) {
                                 LOGGER.warning(String.format(
-                                    "Body as map output cannot be set. Response content is not valid json(%s).",
+                                    "BodyAsObject output cannot be set. Response content is not valid json(%s).",
                                     bodyResponse));
                             }
                         } else {

--- a/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
@@ -472,6 +472,106 @@ public class RESTConnectorTest extends AcceptanceTestBase {
         assertEquals(bodyAsMap.get("name"), "Romain");
     }
 
+    /**
+     * Test the json simple string value
+     * 
+     * @throws BonitaException exception
+     * @throws InterruptedException exception
+     */
+    @Test
+    public void json_simple_string_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("\"this is a string\"")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsMap);
+        assertEquals(bodyAsMap.size(), 0);
+    }
+
+    /**
+     * Test the json simple numeric value
+     * 
+     * @throws BonitaException exception
+     * @throws InterruptedException exception
+     */
+    @Test
+    public void json_simple_numeric_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("123.45")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsMap);
+        assertEquals(bodyAsMap.size(), 0);
+    }
+
+    /**
+     * Test the json simple boolean value
+     * 
+     * @throws BonitaException exception
+     * @throws InterruptedException exception
+     */
+    @Test
+    public void json_simple_boolean_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("true")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsMap);
+        assertEquals(bodyAsMap.size(), 0);
+    }
+
+    /**
+     * Test the json simple date value
+     * 
+     * @throws BonitaException exception
+     * @throws InterruptedException exception
+     */
+    @Test
+    public void json_simple_date_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("2012-04-23T18:25:43.511Z")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsMap);
+        assertEquals(bodyAsMap.size(), 0);
+    }
+
+    /**
+     * Test the json simple null value
+     * 
+     * @throws BonitaException exception
+     * @throws InterruptedException exception
+     */
+    @Test
+    public void json_simple_null_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("null")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsMap);
+        assertEquals(bodyAsMap.size(), 0);
+    }
+
     @Test
     public void should_retrieve_response_as_a_List_of_Map__jsonContentType() throws BonitaException, InterruptedException {
         stubFor(post(urlEqualTo("/"))

--- a/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
@@ -26,9 +26,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -473,13 +477,34 @@ public class RESTConnectorTest extends AcceptanceTestBase {
     }
 
     /**
+     * Test the json content type with wrong content
+     * 
+     * @throws BonitaException exception
+     * @throws InterruptedException exception
+     */
+    @Test
+    public void should_not_raise_exception_on_json_parsing_error() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("{ this is not valid json ! }")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final Map<String, Object> bodyAsMap = (Map<String, Object>) outputs
+                .get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsMap);
+        assertEquals(bodyAsMap.size(), 0);
+    }
+
+    /**
      * Test the json simple string value
      * 
      * @throws BonitaException exception
      * @throws InterruptedException exception
      */
     @Test
-    public void json_simple_string_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+    public void json_simple_string_value_should_return_string_object() throws BonitaException, InterruptedException {
         stubFor(post(urlEqualTo("/"))
                 .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
                 .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("\"this is a string\"")
@@ -487,9 +512,10 @@ public class RESTConnectorTest extends AcceptanceTestBase {
 
         final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
         checkResultIsPresent(outputs);
-        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-        assertNotNull(bodyAsMap);
-        assertEquals(bodyAsMap.size(), 0);
+        final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsObject);
+        final String bodyAsString = (String) bodyAsObject;
+        assertEquals(bodyAsString, "this is a string");
     }
 
     /**
@@ -499,7 +525,7 @@ public class RESTConnectorTest extends AcceptanceTestBase {
      * @throws InterruptedException exception
      */
     @Test
-    public void json_simple_numeric_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+    public void json_simple_numeric_value_should_return_number_object() throws BonitaException, InterruptedException {
         stubFor(post(urlEqualTo("/"))
                 .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
                 .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("123.45")
@@ -507,9 +533,10 @@ public class RESTConnectorTest extends AcceptanceTestBase {
 
         final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
         checkResultIsPresent(outputs);
-        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-        assertNotNull(bodyAsMap);
-        assertEquals(bodyAsMap.size(), 0);
+        final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsObject);
+        final Number bodyAsNumber = (Number) bodyAsObject;
+        assertEquals(bodyAsNumber, 123.45);
     }
 
     /**
@@ -519,7 +546,7 @@ public class RESTConnectorTest extends AcceptanceTestBase {
      * @throws InterruptedException exception
      */
     @Test
-    public void json_simple_boolean_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+    public void json_simple_boolean_value_should_return_boolean_object() throws BonitaException, InterruptedException {
         stubFor(post(urlEqualTo("/"))
                 .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
                 .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("true")
@@ -527,9 +554,10 @@ public class RESTConnectorTest extends AcceptanceTestBase {
 
         final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
         checkResultIsPresent(outputs);
-        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-        assertNotNull(bodyAsMap);
-        assertEquals(bodyAsMap.size(), 0);
+        final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsObject);
+        final Boolean bodyAsBoolean = (Boolean)bodyAsObject;
+        assertEquals(bodyAsBoolean, true);
     }
 
     /**
@@ -539,17 +567,18 @@ public class RESTConnectorTest extends AcceptanceTestBase {
      * @throws InterruptedException exception
      */
     @Test
-    public void json_simple_date_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+    public void json_simple_date_value_should_return_iso8601_date_string() throws BonitaException, InterruptedException {
         stubFor(post(urlEqualTo("/"))
                 .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("2012-04-23T18:25:43.511Z")
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("\"2012-04-23T18:25:43+02:00\"")
                         .withHeader(WM_CONTENT_TYPE, JSON)));
 
         final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
         checkResultIsPresent(outputs);
-        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-        assertNotNull(bodyAsMap);
-        assertEquals(bodyAsMap.size(), 0);
+        final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsObject);
+        final Instant bodyAsInstant = OffsetDateTime.parse((String) bodyAsObject).toInstant();
+        assertEquals(bodyAsInstant, new GregorianCalendar(2012, 3, 23, 18, 25, 43).toInstant());
     }
 
     /**
@@ -559,7 +588,7 @@ public class RESTConnectorTest extends AcceptanceTestBase {
      * @throws InterruptedException exception
      */
     @Test
-    public void json_simple_null_value_should_not_raise_exception() throws BonitaException, InterruptedException {
+    public void json_simple_null_value_should_return_null() throws BonitaException, InterruptedException {
         stubFor(post(urlEqualTo("/"))
                 .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
                 .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("null")
@@ -567,9 +596,8 @@ public class RESTConnectorTest extends AcceptanceTestBase {
 
         final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
         checkResultIsPresent(outputs);
-        final Map<String, Object> bodyAsMap = (Map<String, Object>)outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-        assertNotNull(bodyAsMap);
-        assertEquals(bodyAsMap.size(), 0);
+        final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNull(bodyAsObject);
     }
 
     @Test
@@ -584,6 +612,21 @@ public class RESTConnectorTest extends AcceptanceTestBase {
         final Object bodyAsMap = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
         assertNotNull(bodyAsMap);
         assertEquals(((Map<String, Object>) ((List) bodyAsMap).get(0)).get("name"), "Romain");
+    }
+
+    @Test
+    public void should_retrieve_response_as_a_List_of_string() throws BonitaException, InterruptedException {
+        stubFor(post(urlEqualTo("/"))
+                .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("[\"abc\", \"def\"]")
+                        .withHeader(WM_CONTENT_TYPE, JSON)));
+
+        final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+        checkResultIsPresent(outputs);
+        final List<String> bodyAsList = (List<String>) outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+        assertNotNull(bodyAsList);
+        assertEquals(bodyAsList.get(0), "abc");
+        assertEquals(bodyAsList.get(1), "def");
     }
 
     @Test


### PR DESCRIPTION
Check if json is an object type before trying to deserialize it into a Map.

Closes #42