### PR TITLE
fix(errorManagement): do not fail with an exception when the request status is not successful

### DIFF
--- a/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
@@ -522,9 +522,8 @@ public class RESTConnector extends AbstractRESTConnectorImpl {
             LOGGER.fine("Response recieved.");
             final int statusCode = httpResponse.getStatusLine().getStatusCode();
             if (!statusSuccessful(statusCode)) {
-                throw new ConnectorException(
-                        String.format("%s response status is not successful: %s - %s", request, statusCode,
-                                httpResponse.getStatusLine().getReasonPhrase()));
+                LOGGER.warning(() -> String.format("%s response status is not successful: %s - %s", request, statusCode,
+                        httpResponse.getStatusLine().getReasonPhrase()));
             }
             setOutputs(httpResponse, request);
         } finally {

--- a/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
@@ -919,8 +919,8 @@ public class RESTConnectorTest extends AcceptanceTestBase {
      */
     @Test
     public void noServiceAvailable() throws BonitaException {
-        thrown.expect(ConnectorException.class);
-        executeConnector(buildMethodParametersSet(GET));
+        Map<String, Object> output = executeConnector(buildMethodParametersSet(GET));
+        assertEquals(404, output.get(RESTConnector.STATUS_CODE_OUTPUT_PARAMETER));
     }
 
     /**


### PR DESCRIPTION
* Log a warning instead of throwing an exception
* Error should be handled at process level using the `status code`
connector output