### PR TITLE
Feat/sharepoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,39 @@ jobs:
        fetch-depth: 0
        
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'temurin'
+        cache: 'maven'
 
     - name: Build and test
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-      run: ./mvnw -B clean verify sonar:sonar -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-    - run: mkdir staging && cp target/*.zip staging
+      run: ./mvnw -B clean verify
+
+    - name: Check whether SONAR_TOKEN is set
+      id: is-sonar-set
+      env:
+        SONAR_IS_SET: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        echo "Is Sonar Set: ${{ env.SONAR_IS_SET != '' }}"
+        echo "::set-output name=sonar-enable::${{ env.SONAR_IS_SET != '' }}"
+
+    - name: Run Sonar
+      if: ${{ steps.is-sonar-set.outputs.sonar-enable == 'true' }}
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+      run: ./mvnw -B sonar:sonar -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+
+    - name: Copy artifacts for staging
+      run: |
+        mkdir staging
+        cp target/*.zip staging
+        cp target/*.jar staging
+
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -16,9 +16,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
       
       - name: Extract version
         shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,14 @@
 
 		<!--Post Connector -->
 		<post.def.id>rest-post</post.def.id>
-		<post.def.version>1.3.0</post.def.version>
+		<post.def.version>1.3.1</post.def.version>
 		<post.impl.id>${post.def.id}-impl</post.impl.id>
 		<post.impl.version>${project.version}</post.impl.version>
 		<post.main-class>org.bonitasoft.connectors.rest.PostConnectorImpl</post.main-class>
 
 		<!--Put Connector -->
 		<put.def.id>rest-put</put.def.id>
-		<put.def.version>1.3.0</put.def.version>
+		<put.def.version>1.3.1</put.def.version>
 		<put.impl.id>${put.def.id}-impl</put.impl.id>
 		<put.impl.version>${project.version}</put.impl.version>
 		<put.main-class>org.bonitasoft.connectors.rest.PutConnectorImpl</put.main-class>

--- a/src/main/java/org/bonitasoft/connectors/rest/AbstractRESTConnectorImpl.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/AbstractRESTConnectorImpl.java
@@ -1,25 +1,21 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-
 import org.bonitasoft.connectors.rest.model.AuthorizationType;
 import org.bonitasoft.connectors.rest.model.SSLVerifier;
 import org.bonitasoft.connectors.rest.model.TrustCertificateStrategy;
@@ -28,402 +24,410 @@ import org.bonitasoft.engine.connector.ConnectorValidationException;
 
 public abstract class AbstractRESTConnectorImpl extends AbstractConnector {
 
-	protected static final String URL_INPUT_PARAMETER = "url";
-	protected static final String METHOD_INPUT_PARAMETER = "method";
-	protected static final String CONTENTTYPE_INPUT_PARAMETER = "contentType";
-	protected static final String CHARSET_INPUT_PARAMETER = "charset";
-	protected static final String URLCOOKIES_INPUT_PARAMETER = "urlCookies";
-	protected static final String URLHEADERS_INPUT_PARAMETER = "urlHeaders";
-	protected static final String BODY_INPUT_PARAMETER = "body";
-	protected static final String DO_NOT_FOLLOW_REDIRECT_INPUT_PARAMETER = "do_not_follow_redirect";
-	protected static final String IGNORE_BODY_INPUT_PARAMETER = "ignore_body";
-	protected static final String TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER = "trust_strategy";
-	protected static final String TLS_INPUT_PARAMETER = "TLS";
-	protected static final String HOSTNAME_VERIFIER_INPUT_PARAMETER = "hostname_verifier";
-	protected static final String TRUST_STORE_FILE_INPUT_PARAMETER = "trust_store_file";
-	protected static final String TRUST_STORE_PASSWORD_INPUT_PARAMETER = "trust_store_password";
-	protected static final String KEY_STORE_FILE_INPUT_PARAMETER = "key_store_file";
-	protected static final String KEY_STORE_PASSWORD_INPUT_PARAMETER = "key_store_password";
-	protected static final String AUTH_TYPE_PARAMETER = "auth_type";
-	protected static final String AUTH_USERNAME_INPUT_PARAMETER = "auth_username";
-	protected static final String AUTH_PASSWORD_INPUT_PARAMETER = "auth_password";
-	protected static final String AUTH_HOST_INPUT_PARAMETER = "auth_host";
-	protected static final String AUTH_PORT_INPUT_PARAMETER = "auth_port";
-	protected static final String AUTH_REALM_INPUT_PARAMETER = "auth_realm";
-	protected static final String AUTH_PREEMPTIVE_INPUT_PARAMETER = "auth_preemptive";
-	protected static final String PROXY_PROTOCOL_INPUT_PARAMETER = "proxy_protocol";
-	protected static final String PROXY_HOST_INPUT_PARAMETER = "proxy_host";
-	protected static final String PROXY_PORT_INPUT_PARAMETER = "proxy_port";
-	protected static final String PROXY_USERNAME_INPUT_PARAMETER = "proxy_username";
-	protected static final String PROXY_PASSWORD_INPUT_PARAMETER = "proxy_password";
-	protected static final String BODY_AS_STRING_OUTPUT_PARAMETER = "bodyAsString";
-	protected static final String BODY_AS_OBJECT_OUTPUT_PARAMETER = "bodyAsObject";
-	protected static final String HEADERS_OUTPUT_PARAMETER = "headers";
-	protected static final String STATUS_CODE_OUTPUT_PARAMETER = "status_code";
-	protected static final String STATUS_MESSAGE_OUTPUT_PARAMETER = "status_message";
-	protected static final String SOCKET_TIMEOUT_MS_PARAMETER = "socket_timeout_ms";
-	protected static final String CONNECTION_TIMEOUT_MS_PARAMETER = "connection_timeout_ms";
+  protected static final String URL_INPUT_PARAMETER = "url";
+  protected static final String METHOD_INPUT_PARAMETER = "method";
+  protected static final String CONTENTTYPE_INPUT_PARAMETER = "contentType";
+  protected static final String CHARSET_INPUT_PARAMETER = "charset";
+  protected static final String URLCOOKIES_INPUT_PARAMETER = "urlCookies";
+  protected static final String URLHEADERS_INPUT_PARAMETER = "urlHeaders";
+  protected static final String BODY_INPUT_PARAMETER = "body";
+  protected static final String DO_NOT_FOLLOW_REDIRECT_INPUT_PARAMETER = "do_not_follow_redirect";
+  protected static final String IGNORE_BODY_INPUT_PARAMETER = "ignore_body";
+  protected static final String TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER = "trust_strategy";
+  protected static final String TLS_INPUT_PARAMETER = "TLS";
+  protected static final String HOSTNAME_VERIFIER_INPUT_PARAMETER = "hostname_verifier";
+  protected static final String TRUST_STORE_FILE_INPUT_PARAMETER = "trust_store_file";
+  protected static final String TRUST_STORE_PASSWORD_INPUT_PARAMETER = "trust_store_password";
+  protected static final String KEY_STORE_FILE_INPUT_PARAMETER = "key_store_file";
+  protected static final String KEY_STORE_PASSWORD_INPUT_PARAMETER = "key_store_password";
+  protected static final String AUTH_TYPE_PARAMETER = "auth_type";
+  protected static final String AUTH_USERNAME_INPUT_PARAMETER = "auth_username";
+  protected static final String AUTH_PASSWORD_INPUT_PARAMETER = "auth_password";
+  protected static final String AUTH_HOST_INPUT_PARAMETER = "auth_host";
+  protected static final String AUTH_PORT_INPUT_PARAMETER = "auth_port";
+  protected static final String AUTH_REALM_INPUT_PARAMETER = "auth_realm";
+  protected static final String AUTH_PREEMPTIVE_INPUT_PARAMETER = "auth_preemptive";
+  protected static final String PROXY_PROTOCOL_INPUT_PARAMETER = "proxy_protocol";
+  protected static final String PROXY_HOST_INPUT_PARAMETER = "proxy_host";
+  protected static final String PROXY_PORT_INPUT_PARAMETER = "proxy_port";
+  protected static final String PROXY_USERNAME_INPUT_PARAMETER = "proxy_username";
+  protected static final String PROXY_PASSWORD_INPUT_PARAMETER = "proxy_password";
+  protected static final String BODY_AS_STRING_OUTPUT_PARAMETER = "bodyAsString";
+  protected static final String BODY_AS_OBJECT_OUTPUT_PARAMETER = "bodyAsObject";
+  protected static final String HEADERS_OUTPUT_PARAMETER = "headers";
+  protected static final String STATUS_CODE_OUTPUT_PARAMETER = "status_code";
+  protected static final String STATUS_MESSAGE_OUTPUT_PARAMETER = "status_message";
+  protected static final String SOCKET_TIMEOUT_MS_PARAMETER = "socket_timeout_ms";
+  protected static final String CONNECTION_TIMEOUT_MS_PARAMETER = "connection_timeout_ms";
 
-	protected static final int SOCKET_TIMEOUT_MS_DEFAULT_VALUE = 60_000;
-	protected static final int CONNECTION_TIMEOUT_MS_DEFAULT_VALUE = 60_000;
+  protected static final int SOCKET_TIMEOUT_MS_DEFAULT_VALUE = 60_000;
+  protected static final int CONNECTION_TIMEOUT_MS_DEFAULT_VALUE = 60_000;
 
-	protected final java.lang.String getUrl() {
-		return (java.lang.String) getInputParameter(URL_INPUT_PARAMETER);
-	}
+  protected final java.lang.String getUrl() {
+    return (java.lang.String) getInputParameter(URL_INPUT_PARAMETER);
+  }
 
-	protected java.lang.String getMethod() {
-		return (java.lang.String) getInputParameter(METHOD_INPUT_PARAMETER);
-	}
+  protected java.lang.String getMethod() {
+    return (java.lang.String) getInputParameter(METHOD_INPUT_PARAMETER);
+  }
 
-	protected final java.lang.String getContentType() {
-		return (java.lang.String) getInputParameter(CONTENTTYPE_INPUT_PARAMETER);
-	}
+  protected final java.lang.String getContentType() {
+    return (java.lang.String) getInputParameter(CONTENTTYPE_INPUT_PARAMETER);
+  }
 
-	protected final java.lang.String getCharset() {
-		return (java.lang.String) getInputParameter(CHARSET_INPUT_PARAMETER);
-	}
+  protected final java.lang.String getCharset() {
+    return (java.lang.String) getInputParameter(CHARSET_INPUT_PARAMETER);
+  }
 
-	protected final List getUrlCookies() {
-		List cookies = (List) getInputParameter(URLCOOKIES_INPUT_PARAMETER);
-		if (cookies == null) {
-			cookies = Collections.emptyList();
-		}
-		cookies.removeIf(emptyLines());
-		return cookies;
-	}
+  protected final List getUrlCookies() {
+    List cookies = (List) getInputParameter(URLCOOKIES_INPUT_PARAMETER);
+    if (cookies == null) {
+      cookies = Collections.emptyList();
+    }
+    cookies.removeIf(emptyLines());
+    return cookies;
+  }
 
-	private Predicate<Object> emptyLines() {
-		return new Predicate<Object>() {
+  private Predicate<Object> emptyLines() {
+    return new Predicate<Object>() {
 
-			@Override
-			public boolean test(Object input) {
-				if (input instanceof List) {
-					final List line = (List) input;
-					return line.size() != 2 || (emptyCell(line, 0) && emptyCell(line, 1));
-				}
-				return true;
-			}
+      @Override
+      public boolean test(Object input) {
+        if (input instanceof List) {
+          final List line = (List) input;
+          return line.size() != 2 || (emptyCell(line, 0) && emptyCell(line, 1));
+        }
+        return true;
+      }
 
-			private boolean emptyCell(final List line, int cellIndex) {
-				final Object cellValue = line.get(cellIndex);
-				return cellValue == null || cellValue.toString().trim().isEmpty();
-			}
-		};
-	}
+      private boolean emptyCell(final List line, int cellIndex) {
+        final Object cellValue = line.get(cellIndex);
+        return cellValue == null || cellValue.toString().trim().isEmpty();
+      }
+    };
+  }
 
-	protected final List getUrlHeaders() {
-		List headers = (List) getInputParameter(URLHEADERS_INPUT_PARAMETER);
-		if (headers == null) {
-			headers = Collections.emptyList();
-		}
-		headers.removeIf(emptyLines());
-		return headers;
-	}
+  protected final List getUrlHeaders() {
+    List headers = (List) getInputParameter(URLHEADERS_INPUT_PARAMETER);
+    if (headers == null) {
+      headers = Collections.emptyList();
+    }
+    headers.removeIf(emptyLines());
+    return headers;
+  }
 
-	protected final String getBody() {
-		return (String) getInputParameter(BODY_INPUT_PARAMETER);
-	}
+  protected final Serializable getBody() {
+    return (Serializable) getInputParameter(BODY_INPUT_PARAMETER);
+  }
 
-	protected final Boolean getTLS() {
-		final Boolean tlsParam = (Boolean) getInputParameter(TLS_INPUT_PARAMETER);
-		return tlsParam != null ? tlsParam : Boolean.TRUE;
-	}
+  protected final Boolean getTLS() {
+    final Boolean tlsParam = (Boolean) getInputParameter(TLS_INPUT_PARAMETER);
+    return tlsParam != null ? tlsParam : Boolean.TRUE;
+  }
 
-	protected final TrustCertificateStrategy getTrustCertificateStrategy() {
-		final String trustParam = (String) getInputParameter(TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER);
-		if (trustParam != null && !trustParam.trim().isEmpty()) {
-			return TrustCertificateStrategy.valueOf(trustParam);
-		}
-		return TrustCertificateStrategy.DEFAULT;
-	}
+  protected final TrustCertificateStrategy getTrustCertificateStrategy() {
+    final String trustParam =
+        (String) getInputParameter(TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER);
+    if (trustParam != null && !trustParam.trim().isEmpty()) {
+      return TrustCertificateStrategy.valueOf(trustParam);
+    }
+    return TrustCertificateStrategy.DEFAULT;
+  }
 
-	protected final SSLVerifier getHostnameVerifier() {
-		String hostanmeVerifierParam = (String) getInputParameter(HOSTNAME_VERIFIER_INPUT_PARAMETER);
-		if(hostanmeVerifierParam != null && !hostanmeVerifierParam.trim().isEmpty()) {
-			return SSLVerifier.getSSLVerifierFromValue(hostanmeVerifierParam.toUpperCase());
-		}
-		return SSLVerifier.STRICT;
-	}
+  protected final SSLVerifier getHostnameVerifier() {
+    String hostanmeVerifierParam = (String) getInputParameter(HOSTNAME_VERIFIER_INPUT_PARAMETER);
+    if (hostanmeVerifierParam != null && !hostanmeVerifierParam.trim().isEmpty()) {
+      return SSLVerifier.getSSLVerifierFromValue(hostanmeVerifierParam.toUpperCase());
+    }
+    return SSLVerifier.STRICT;
+  }
 
-	protected final String getTrustStoreFile() {
-		return (String) getInputParameter(TRUST_STORE_FILE_INPUT_PARAMETER);
-	}
+  protected final String getTrustStoreFile() {
+    return (String) getInputParameter(TRUST_STORE_FILE_INPUT_PARAMETER);
+  }
 
-	protected final String getTrustStorePassword() {
-		return (String) getInputParameter(TRUST_STORE_PASSWORD_INPUT_PARAMETER);
-	}
+  protected final String getTrustStorePassword() {
+    return (String) getInputParameter(TRUST_STORE_PASSWORD_INPUT_PARAMETER);
+  }
 
-	protected final String getKeyStoreFile() {
-		return (String) getInputParameter(KEY_STORE_FILE_INPUT_PARAMETER);
-	}
+  protected final String getKeyStoreFile() {
+    return (String) getInputParameter(KEY_STORE_FILE_INPUT_PARAMETER);
+  }
 
-	protected final String getKeyStorePassword() {
-		return (String) getInputParameter(KEY_STORE_PASSWORD_INPUT_PARAMETER);
-	}
+  protected final String getKeyStorePassword() {
+    return (String) getInputParameter(KEY_STORE_PASSWORD_INPUT_PARAMETER);
+  }
 
-	protected final Boolean getDoNotFollowRedirect() {
-		final Boolean follozRedirect = (Boolean) getInputParameter(DO_NOT_FOLLOW_REDIRECT_INPUT_PARAMETER);
-		return follozRedirect != null ? follozRedirect : Boolean.FALSE;
-	}
+  protected final Boolean getDoNotFollowRedirect() {
+    final Boolean follozRedirect =
+        (Boolean) getInputParameter(DO_NOT_FOLLOW_REDIRECT_INPUT_PARAMETER);
+    return follozRedirect != null ? follozRedirect : Boolean.FALSE;
+  }
 
-	protected final Boolean getIgnoreBody() {
-		final Boolean ignoreBody = (Boolean) getInputParameter(IGNORE_BODY_INPUT_PARAMETER);
-		return ignoreBody != null ? ignoreBody : Boolean.FALSE;
-	}
+  protected final Boolean getIgnoreBody() {
+    final Boolean ignoreBody = (Boolean) getInputParameter(IGNORE_BODY_INPUT_PARAMETER);
+    return ignoreBody != null ? ignoreBody : Boolean.FALSE;
+  }
 
-	protected final String getAuthUsername() {
-		return (String) getInputParameter(AUTH_USERNAME_INPUT_PARAMETER);
-	}
+  protected final String getAuthUsername() {
+    return (String) getInputParameter(AUTH_USERNAME_INPUT_PARAMETER);
+  }
 
-	protected final String getAuthPassword() {
-		return (String) getInputParameter(AUTH_PASSWORD_INPUT_PARAMETER);
-	}
+  protected final String getAuthPassword() {
+    return (String) getInputParameter(AUTH_PASSWORD_INPUT_PARAMETER);
+  }
 
-	protected final String getAuthHost() {
-		return (String) getInputParameter(AUTH_HOST_INPUT_PARAMETER);
-	}
+  protected final String getAuthHost() {
+    return (String) getInputParameter(AUTH_HOST_INPUT_PARAMETER);
+  }
 
-	protected final Integer getAuthPort() {
-		return (Integer) getInputParameter(AUTH_PORT_INPUT_PARAMETER);
-	}
+  protected final Integer getAuthPort() {
+    return (Integer) getInputParameter(AUTH_PORT_INPUT_PARAMETER);
+  }
 
-	protected final String getAuthRealm() {
-		return (String) getInputParameter(AUTH_REALM_INPUT_PARAMETER);
-	}
+  protected final String getAuthRealm() {
+    return (String) getInputParameter(AUTH_REALM_INPUT_PARAMETER);
+  }
 
-	protected final Boolean getAuthPreemptive() {
-		final Boolean preemptive = (Boolean) getInputParameter(AUTH_PREEMPTIVE_INPUT_PARAMETER);
-		return preemptive != null ? preemptive : Boolean.TRUE;
-	}
+  protected final Boolean getAuthPreemptive() {
+    final Boolean preemptive = (Boolean) getInputParameter(AUTH_PREEMPTIVE_INPUT_PARAMETER);
+    return preemptive != null ? preemptive : Boolean.TRUE;
+  }
 
-	protected final AuthorizationType getAuthType() {
-		final String authType = (String) getInputParameter(AUTH_TYPE_PARAMETER);
-		return authType != null ? AuthorizationType.valueOf(authType) : AuthorizationType.NONE;
-	}
+  protected final AuthorizationType getAuthType() {
+    final String authType = (String) getInputParameter(AUTH_TYPE_PARAMETER);
+    return authType != null ? AuthorizationType.valueOf(authType) : AuthorizationType.NONE;
+  }
 
-	protected final java.lang.String getProxyProtocol() {
-		return (String) getInputParameter(PROXY_PROTOCOL_INPUT_PARAMETER);
-	}
+  protected final java.lang.String getProxyProtocol() {
+    return (String) getInputParameter(PROXY_PROTOCOL_INPUT_PARAMETER);
+  }
 
-	protected final String getProxyHost() {
-		return (String) getInputParameter(PROXY_HOST_INPUT_PARAMETER);
-	}
+  protected final String getProxyHost() {
+    return (String) getInputParameter(PROXY_HOST_INPUT_PARAMETER);
+  }
 
-	protected final Integer getProxyPort() {
-		return (Integer) getInputParameter(PROXY_PORT_INPUT_PARAMETER);
-	}
+  protected final Integer getProxyPort() {
+    return (Integer) getInputParameter(PROXY_PORT_INPUT_PARAMETER);
+  }
 
-	protected final String getProxyUsername() {
-		return (String) getInputParameter(PROXY_USERNAME_INPUT_PARAMETER);
-	}
+  protected final String getProxyUsername() {
+    return (String) getInputParameter(PROXY_USERNAME_INPUT_PARAMETER);
+  }
 
-	protected final String getProxyPassword() {
-		return (String) getInputParameter(PROXY_PASSWORD_INPUT_PARAMETER);
-	}
+  protected final String getProxyPassword() {
+    return (String) getInputParameter(PROXY_PASSWORD_INPUT_PARAMETER);
+  }
 
-	protected final Integer getSocketTimeoutMs() {
-		Integer socketTimeoutMs = (Integer) getInputParameter(SOCKET_TIMEOUT_MS_PARAMETER);
-		return socketTimeoutMs != null ? socketTimeoutMs : SOCKET_TIMEOUT_MS_DEFAULT_VALUE;
-	}
+  protected final Integer getSocketTimeoutMs() {
+    Integer socketTimeoutMs = (Integer) getInputParameter(SOCKET_TIMEOUT_MS_PARAMETER);
+    return socketTimeoutMs != null ? socketTimeoutMs : SOCKET_TIMEOUT_MS_DEFAULT_VALUE;
+  }
 
-	protected final Integer getConnectionTimeoutMs() {
-		Integer connectionTimeoutMs = (Integer) getInputParameter(CONNECTION_TIMEOUT_MS_PARAMETER);
-		return connectionTimeoutMs != null ? connectionTimeoutMs : CONNECTION_TIMEOUT_MS_DEFAULT_VALUE;
-	}
+  protected final Integer getConnectionTimeoutMs() {
+    Integer connectionTimeoutMs = (Integer) getInputParameter(CONNECTION_TIMEOUT_MS_PARAMETER);
+    return connectionTimeoutMs != null ? connectionTimeoutMs : CONNECTION_TIMEOUT_MS_DEFAULT_VALUE;
+  }
 
-	protected final void setBody(java.lang.String body) {
-		setOutputParameter(BODY_AS_STRING_OUTPUT_PARAMETER, body);
-	}
+  protected final void setBody(java.lang.String body) {
+    setOutputParameter(BODY_AS_STRING_OUTPUT_PARAMETER, body);
+  }
 
-	protected final void setBody(Object body) {
-		setOutputParameter(BODY_AS_OBJECT_OUTPUT_PARAMETER, body);
-	}
+  protected final void setBody(Object body) {
+    setOutputParameter(BODY_AS_OBJECT_OUTPUT_PARAMETER, body);
+  }
 
-	protected final void setHeaders(Map<String, String> headers) {
-		setOutputParameter(HEADERS_OUTPUT_PARAMETER, headers);
-	}
+  protected final void setHeaders(Map<String, String> headers) {
+    setOutputParameter(HEADERS_OUTPUT_PARAMETER, headers);
+  }
 
-	protected final void setStatusCode(java.lang.Integer statusCode) {
-		setOutputParameter(STATUS_CODE_OUTPUT_PARAMETER, statusCode);
-	}
+  protected final void setStatusCode(java.lang.Integer statusCode) {
+    setOutputParameter(STATUS_CODE_OUTPUT_PARAMETER, statusCode);
+  }
 
-	protected final void setStatusMessage(java.lang.String statusMessage) {
-		setOutputParameter(STATUS_MESSAGE_OUTPUT_PARAMETER, statusMessage);
-	}
+  protected final void setStatusMessage(java.lang.String statusMessage) {
+    setOutputParameter(STATUS_MESSAGE_OUTPUT_PARAMETER, statusMessage);
+  }
 
-	@Override
-	public void validateInputParameters() throws ConnectorValidationException {
-		try {
-			getUrl();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("url type is invalid");
-		}
-		try {
-			getMethod();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("method type is invalid");
-		}
-		try {
-			getContentType();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("contentType type is invalid");
-		}
-		try {
-			getCharset();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("charset type is invalid");
-		}
-		try {
-			getUrlCookies();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("urlCookies type is invalid");
-		}
-		try {
-			getUrlHeaders();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("urlHeaders type is invalid");
-		}
-		try {
-			getBody();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("body type is invalid");
-		}
-		try {
-			getDoNotFollowRedirect();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("do_not_follow_redirect type is invalid");
-		}
-		try {
-			getIgnoreBody();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("ignore_body type is invalid");
-		}
-		try {
-			getTLS();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("TLS type is invalid");
-		}
-		validateTrustCertificateStrategyInput();
-		validateHostnameVerifierInput();
-		
-		try {
-			getTrustStoreFile();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("trust_store_file type is invalid");
-		}
-		try {
-			getTrustStorePassword();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("trust_store_password type is invalid");
-		}
-		try {
-			getKeyStoreFile();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("key_store_file type is invalid");
-		}
-		try {
-			getKeyStorePassword();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("key_store_password type is invalid");
-		}
-		try {
-			getAuthUsername();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("auth_basic_username type is invalid");
-		}
-		try {
-			getAuthPassword();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("auth_basic_password type is invalid");
-		}
-		try {
-			getAuthHost();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("auth_basic_host type is invalid");
-		}
-		try {
-			getAuthPort();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("auth_basic_port type is invalid");
-		}
-		try {
-			getAuthRealm();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("auth_basic_realm type is invalid");
-		}
-		try {
-			getAuthPreemptive();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("auth_basic_preemptive type is invalid");
-		}
-		try {
-			getProxyProtocol();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("proxy_protocol type is invalid");
-		}
-		try {
-			getProxyHost();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("proxy_host type is invalid");
-		}
-		try {
-			getProxyPort();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("proxy_port type is invalid");
-		}
-		try {
-			getProxyUsername();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("proxy_username type is invalid");
-		}
-		try {
-			getProxyPassword();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException("proxy_password type is invalid");
-		}
-		try {
-			getSocketTimeoutMs();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException(SOCKET_TIMEOUT_MS_PARAMETER + " type is invalid");
-		}
-		try {
-			getConnectionTimeoutMs();
-		} catch (final ClassCastException cce) {
-			throw new ConnectorValidationException(CONNECTION_TIMEOUT_MS_PARAMETER + " type is invalid");
-		}
-	}
+  @Override
+  public void validateInputParameters() throws ConnectorValidationException {
+    try {
+      getUrl();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("url type is invalid");
+    }
+    try {
+      getMethod();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("method type is invalid");
+    }
+    try {
+      getContentType();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("contentType type is invalid");
+    }
+    try {
+      getCharset();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("charset type is invalid");
+    }
+    try {
+      getUrlCookies();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("urlCookies type is invalid");
+    }
+    try {
+      getUrlHeaders();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("urlHeaders type is invalid");
+    }
+    try {
+      getBody();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("body type is invalid");
+    }
+    try {
+      getDoNotFollowRedirect();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("do_not_follow_redirect type is invalid");
+    }
+    try {
+      getIgnoreBody();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("ignore_body type is invalid");
+    }
+    try {
+      getTLS();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("TLS type is invalid");
+    }
+    validateTrustCertificateStrategyInput();
+    validateHostnameVerifierInput();
 
-	private void validateTrustCertificateStrategyInput() throws ConnectorValidationException {
-		String trustParam = null;
-		try {
-			trustParam = (String) getInputParameter(TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER);
-			if (trustParam != null && !trustParam.trim().isEmpty()) {
-				TrustCertificateStrategy.valueOf(trustParam);
-			}
-		} catch (ClassCastException cce) {
-			throw new ConnectorValidationException(
-					String.format("%s type is invalid", TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER));
-		} catch (IllegalArgumentException e) {
-			throw new ConnectorValidationException(String.format(
-					"'%s' option is invalid for %s. Only one of %s is supported.", trustParam,
-					TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, Arrays.toString(TrustCertificateStrategy.values())));
-		}
-	}
-	
-	private void validateHostnameVerifierInput() throws ConnectorValidationException {
-		String hostNameVerifierParam = null;
-		try {
-			hostNameVerifierParam = (String) getInputParameter(HOSTNAME_VERIFIER_INPUT_PARAMETER);
-			if (hostNameVerifierParam != null && !hostNameVerifierParam.trim().isEmpty()) {
-				SSLVerifier.getSSLVerifierFromValue(hostNameVerifierParam.toUpperCase());
-			}
-		} catch (ClassCastException cce) {
-			throw new ConnectorValidationException(
-					String.format("%s type is invalid", HOSTNAME_VERIFIER_INPUT_PARAMETER));
-		} catch (IllegalArgumentException e) {
-			throw new ConnectorValidationException(String.format(
-					"'%s' option is invalid for %s. Only one of %s is supported.", hostNameVerifierParam,
-					HOSTNAME_VERIFIER_INPUT_PARAMETER, Arrays.toString(SSLVerifier.values())));
-		}
-	}
+    try {
+      getTrustStoreFile();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("trust_store_file type is invalid");
+    }
+    try {
+      getTrustStorePassword();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("trust_store_password type is invalid");
+    }
+    try {
+      getKeyStoreFile();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("key_store_file type is invalid");
+    }
+    try {
+      getKeyStorePassword();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("key_store_password type is invalid");
+    }
+    try {
+      getAuthUsername();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("auth_basic_username type is invalid");
+    }
+    try {
+      getAuthPassword();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("auth_basic_password type is invalid");
+    }
+    try {
+      getAuthHost();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("auth_basic_host type is invalid");
+    }
+    try {
+      getAuthPort();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("auth_basic_port type is invalid");
+    }
+    try {
+      getAuthRealm();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("auth_basic_realm type is invalid");
+    }
+    try {
+      getAuthPreemptive();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("auth_basic_preemptive type is invalid");
+    }
+    try {
+      getProxyProtocol();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("proxy_protocol type is invalid");
+    }
+    try {
+      getProxyHost();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("proxy_host type is invalid");
+    }
+    try {
+      getProxyPort();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("proxy_port type is invalid");
+    }
+    try {
+      getProxyUsername();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("proxy_username type is invalid");
+    }
+    try {
+      getProxyPassword();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException("proxy_password type is invalid");
+    }
+    try {
+      getSocketTimeoutMs();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException(SOCKET_TIMEOUT_MS_PARAMETER + " type is invalid");
+    }
+    try {
+      getConnectionTimeoutMs();
+    } catch (final ClassCastException cce) {
+      throw new ConnectorValidationException(CONNECTION_TIMEOUT_MS_PARAMETER + " type is invalid");
+    }
+  }
+
+  private void validateTrustCertificateStrategyInput() throws ConnectorValidationException {
+    String trustParam = null;
+    try {
+      trustParam = (String) getInputParameter(TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER);
+      if (trustParam != null && !trustParam.trim().isEmpty()) {
+        TrustCertificateStrategy.valueOf(trustParam);
+      }
+    } catch (ClassCastException cce) {
+      throw new ConnectorValidationException(
+          String.format("%s type is invalid", TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER));
+    } catch (IllegalArgumentException e) {
+      throw new ConnectorValidationException(
+          String.format(
+              "'%s' option is invalid for %s. Only one of %s is supported.",
+              trustParam,
+              TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER,
+              Arrays.toString(TrustCertificateStrategy.values())));
+    }
+  }
+
+  private void validateHostnameVerifierInput() throws ConnectorValidationException {
+    String hostNameVerifierParam = null;
+    try {
+      hostNameVerifierParam = (String) getInputParameter(HOSTNAME_VERIFIER_INPUT_PARAMETER);
+      if (hostNameVerifierParam != null && !hostNameVerifierParam.trim().isEmpty()) {
+        SSLVerifier.getSSLVerifierFromValue(hostNameVerifierParam.toUpperCase());
+      }
+    } catch (ClassCastException cce) {
+      throw new ConnectorValidationException(
+          String.format("%s type is invalid", HOSTNAME_VERIFIER_INPUT_PARAMETER));
+    } catch (IllegalArgumentException e) {
+      throw new ConnectorValidationException(
+          String.format(
+              "'%s' option is invalid for %s. Only one of %s is supported.",
+              hostNameVerifierParam,
+              HOSTNAME_VERIFIER_INPUT_PARAMETER,
+              Arrays.toString(SSLVerifier.values())));
+    }
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/DeleteConnectorImpl.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/DeleteConnectorImpl.java
@@ -1,27 +1,21 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
 import org.bonitasoft.connectors.rest.model.HTTPMethod;
 
 public class DeleteConnectorImpl extends RESTConnector {
 
-    @Override
-    protected String getMethod() {
-        return HTTPMethod.DELETE.name();
-    }
-
-
+  @Override
+  protected String getMethod() {
+    return HTTPMethod.DELETE.name();
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/GetConnectorImpl.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/GetConnectorImpl.java
@@ -1,27 +1,21 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
 import org.bonitasoft.connectors.rest.model.HTTPMethod;
 
 public class GetConnectorImpl extends RESTConnector {
 
-    @Override
-    protected String getMethod() {
-        return HTTPMethod.GET.name();
-    }
-
-
+  @Override
+  protected String getMethod() {
+    return HTTPMethod.GET.name();
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/PostConnectorImpl.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/PostConnectorImpl.java
@@ -1,27 +1,21 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
 import org.bonitasoft.connectors.rest.model.HTTPMethod;
 
 public class PostConnectorImpl extends RESTConnector {
 
-    @Override
-    protected String getMethod() {
-        return HTTPMethod.POST.name();
-    }
-
-
+  @Override
+  protected String getMethod() {
+    return HTTPMethod.POST.name();
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/PutConnectorImpl.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/PutConnectorImpl.java
@@ -1,27 +1,21 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
 import org.bonitasoft.connectors.rest.model.HTTPMethod;
 
 public class PutConnectorImpl extends RESTConnector {
 
-    @Override
-    protected String getMethod() {
-        return HTTPMethod.PUT.name();
-    }
-
-
+  @Override
+  protected String getMethod() {
+    return HTTPMethod.PUT.name();
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/RESTConnector.java
@@ -1,21 +1,21 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.HttpCookie;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -30,9 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
-
 import javax.net.ssl.HostnameVerifier;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -56,8 +54,8 @@ import org.apache.http.conn.ssl.BrowserCompatHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.auth.AuthSchemeBase;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.auth.DigestScheme;
@@ -84,704 +82,764 @@ import org.bonitasoft.connectors.rest.model.SSL;
 import org.bonitasoft.connectors.rest.model.SSLVerifier;
 import org.bonitasoft.connectors.rest.model.Store;
 import org.bonitasoft.connectors.rest.model.TrustCertificateStrategy;
+import org.bonitasoft.engine.bpm.document.Document;
+import org.bonitasoft.engine.bpm.document.DocumentNotFoundException;
 import org.bonitasoft.engine.connector.ConnectorException;
 import org.bonitasoft.engine.connector.ConnectorValidationException;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-/**
- * This main class of the REST Connector implementation
- */
+/** This main class of the REST Connector implementation */
 public class RESTConnector extends AbstractRESTConnectorImpl {
 
-	/**
-	 * The HTTP request builder constants.
-	 */
-	private static final String HTTP_PROTOCOL = "HTTP";
-	private static final int HTTP_PROTOCOL_VERSION_MAJOR = 1;
-	private static final int HTTP_PROTOCOL_VERSION_MINOR = 1;
-
-	/**
-	 * The class logger
-	 */
-	private static final Logger LOGGER = Logger.getLogger(RESTConnector.class.getName());
-	/**
-	 * Forces the character encoding of the HTTP response body to the default JVM
-	 * Charset if no Charset is defined in the response header. If this property is
-	 * not set, the ISO-8859-1 Charset is used as fallback, as specified in the
-	 * specification.
-	 */
-	static final String DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY = "org.bonitasoft.connectors.rest.response.fallbackToJVMCharset";
-
-	@Override
-	public void validateInputParameters() throws ConnectorValidationException {
-		super.validateInputParameters();
-
-		LOGGER.fine("super validateInputParameters done.");
-
-		final List<String> messages = new ArrayList<>(0);
-		if (!isStringInputValid(getUrl())) {
-			messages.add(URL_INPUT_PARAMETER);
-		} else {
-			try {
-				new URL(getUrl());
-			} catch (final MalformedURLException e) {
-				messages.add(URL_INPUT_PARAMETER);
-			}
-		}
-
-		if (!isStringInputValid(getMethod())) {
-			messages.add(METHOD_INPUT_PARAMETER);
-		}
-
-		if (Objects.equals(getMethod(), HTTPMethod.POST.name()) || Objects.equals(getMethod(), HTTPMethod.PUT.name())) {
-			if (!isStringInputValid(getContentType())) {
-				messages.add(CONTENTTYPE_INPUT_PARAMETER);
-			}
-			if (!isStringInputValid(getCharset())) {
-				messages.add(CHARSET_INPUT_PARAMETER);
-			}
-		}
-
-		final List<?> urlCookies = getUrlCookies();
-		messages.addAll(manageKeyValueCouples(urlCookies, URLCOOKIES_INPUT_PARAMETER));
-
-		final List<?> urlheaders = getUrlHeaders();
-		messages.addAll(manageKeyValueCouples(urlheaders, URLHEADERS_INPUT_PARAMETER));
-
-		if (!messages.isEmpty()) {
-			LOGGER.fine(() -> String.format("validateInputParameters error: %s", messages.toString()));
-			throw new ConnectorValidationException(this, messages);
-		}
-	}
-
-	/**
-	 * Is the String input valid?
-	 * 
-	 * @param value The value to be checked
-	 * @return If the String input is valid or not
-	 */
-	private boolean isStringInputValid(final String value) {
-		return value != null && !value.isEmpty();
-	}
-
-	/**
-	 * Validate the key value couples
-	 * 
-	 * @param keyValueCouples The key value couples from the input
-	 * @param inputName       The input name where the key value couples are from
-	 * @return The error messages if any or empty list otherwise
-	 */
-	private List<String> manageKeyValueCouples(final List<?> keyValueCouples, final String inputName) {
-		final List<String> messages = new ArrayList<>();
-		if (keyValueCouples == null) {
-			return messages;
-		}
-		for (final Object keyValueCouple : keyValueCouples) {
-			if (keyValueCouple instanceof List) {
-				final List<?> keyValueCoupleRow = (List<?>) keyValueCouple;
-				if (!isItAKeyValueCouple(keyValueCoupleRow)) {
-					messages.add(inputName + " - columns - " + keyValueCoupleRow.size());
-				} else if (!isKeyValueCoupleValid(keyValueCoupleRow)) {
-					messages.add(inputName + " - value");
-				}
-			} else {
-				messages.add(inputName + " - type");
-			}
-		}
-		return messages;
-	}
-
-	/**
-	 * Is the key and the value valid?
-	 * 
-	 * @param keyValueCoupleRow The key value couple row
-	 * @return If the key and the value is valid or not
-	 */
-	private boolean isKeyValueCoupleValid(final List<?> keyValueCoupleRow) {
-		return keyValueCoupleRow.get(0) != null && !keyValueCoupleRow.get(0).toString().isEmpty()
-				&& keyValueCoupleRow.get(1) != null;
-	}
-
-	/**
-	 * Is the row a key value couple?
-	 * 
-	 * @param keyValueCoupleRow the list of elements stating the row
-	 * @return If the row is a key value couple or not
-	 */
-	private boolean isItAKeyValueCouple(final List<?> keyValueCoupleRow) {
-		return keyValueCoupleRow.size() == 2;
-	}
-
-	@Override
-	protected void executeBusinessLogic() throws ConnectorException {
-		try {
-			final Request request = buildRequest();
-			execute(request);
-		} catch (final Exception e) {
-			logException(e);
-			throw new ConnectorException(e);
-		}
-	}
-
-	/**
-	 * Build the request bean from all the inputs
-	 * 
-	 * @return The request bean
-	 * @throws MalformedURLException
-	 */
-	private Request buildRequest() throws MalformedURLException {
-		final Request request = new Request();
-		request.setUrl(new URL(getUrl()));
-		LOGGER.fine("URL set to: " + request.getUrl().toString());
-		String bodyStr = "";
-		if (getBody() != null) {
-			bodyStr = getBody();
-		}
-		
-		request.setBody(bodyStr);
-		LOGGER.fine("Body set to: " + request.getBody().toString());
-		request.setRestMethod(HTTPMethod.getRESTHTTPMethodFromValue(getMethod()));
-		
-		if(request.getRestMethod() == HTTPMethod.POST || request.getRestMethod() == HTTPMethod.PUT) {
-		    request.setContentType(ContentType.create(getContentType(), Charset.forName(getCharset())));
-		}
-		
-		LOGGER.fine("Method set to: " + request.getRestMethod().toString());
-		request.setRedirect(!getDoNotFollowRedirect());
-		LOGGER.fine("Follow redirect set to: " + request.isRedirect());
-		request.setIgnore(getIgnoreBody());
-		LOGGER.fine("Ignore body set to: " + request.isIgnore());
-		for (final Object urlheader : getUrlHeaders()) {
-			final List<?> urlheaderRow = (List<?>) urlheader;
-			String name = urlheaderRow.get(0).toString();
-            String value = urlheaderRow.get(1).toString();
-            request.addHeader(name, value);
-			LOGGER.fine("Add header: " + urlheaderRow.get(0).toString() + " set as " + urlheaderRow.get(1).toString());
-		}
-		for (final Object urlCookie : getUrlCookies()) {
-			final List<?> urlCookieRow = (List<?>) urlCookie;
-			request.addCookie(urlCookieRow.get(0).toString(), urlCookieRow.get(1).toString());
-			LOGGER.fine("Add cookie: " + urlCookieRow.get(0).toString() + " set as " + urlCookieRow.get(1).toString());
-		}
-
-		request.setSsl(buildSSL());
-		LOGGER.fine("Add the SSL options");
-
-		if (isProxySet()) {
-			request.setProxy(buildProxy());
-			LOGGER.fine("Add the Proxy options");
-		}
-
-		if (getAuthType() == AuthorizationType.BASIC) {
-			LOGGER.fine("Add basic auth");
-			request.setAuthorization(buildBasicAuthorization());
-		} else if (getAuthType() == AuthorizationType.DIGEST) {
-			LOGGER.fine("Add digest auth");
-			request.setAuthorization(buildDigestAuthorization());
-		}
-		return request;
-	}
-
-	/**
-	 * Is a Proxy used?
-	 * 
-	 * @return If a Proxy is used or not
-	 */
-	private boolean isProxySet() {
-		return isStringInputValid(getProxyHost()) && isStringInputValid(getProxyProtocol());
-	}
-
-	/**
-	 * Build the Digest Auth bean for the request builder
-	 * 
-	 * @return The Digest Auth according to the input values
-	 */
-	private BasicDigestAuthorization buildDigestAuthorization() {
-		final BasicDigestAuthorization authorization = new BasicDigestAuthorization(false);
-		authorization.setUsername(getAuthUsername());
-		authorization.setPassword(getAuthPassword());
-
-		if (isStringInputValid(getAuthHost())) {
-			authorization.setHost(getAuthHost());
-		}
-		authorization.setPort(getAuthPort());
-		if (isStringInputValid(getAuthRealm())) {
-			authorization.setRealm(getAuthRealm());
-		}
-		authorization.setPreemptive(getAuthPreemptive());
-		return authorization;
-	}
-
-	/**
-	 * Build the Basic Auth bean for the request builder
-	 * 
-	 * @return The Basic Auth according to the input values
-	 */
-	private BasicDigestAuthorization buildBasicAuthorization() {
-		final BasicDigestAuthorization authorization = new BasicDigestAuthorization(true);
-		authorization.setUsername(getAuthUsername());
-		authorization.setPassword(getAuthPassword());
-
-		if (isStringInputValid(getAuthHost())) {
-			authorization.setHost(getAuthHost());
-		}
-		authorization.setPort(getAuthPort());
-		if (isStringInputValid(getAuthRealm())) {
-			authorization.setRealm(getAuthRealm());
-		}
-		authorization.setPreemptive(getAuthPreemptive());
-
-		return authorization;
-	}
-
-	/**
-	 * Build the SSL Req bean for the request builder
-	 * 
-	 * @return The SSL Req according to the input values
-	 */
-	private SSL buildSSL() {
-		final SSL ssl = new SSL();
-		ssl.setSslVerifier(getHostnameVerifier());
-		ssl.setTrustCertificateStrategy(getTrustCertificateStrategy());
-		ssl.setUseTLS(getTLS());
-
-		if (isStringInputValid(getTrustStoreFile()) && isStringInputValid(getTrustStorePassword())) {
-			final Store trustStore = new Store();
-			trustStore.setFile(new File(getTrustStoreFile()));
-			trustStore.setPassword(getTrustStorePassword());
-			ssl.setTrustStore(trustStore);
-		}
-
-		if (isStringInputValid(getKeyStoreFile()) && isStringInputValid(getKeyStorePassword())) {
-			final Store keyStore = new Store();
-			keyStore.setFile(new File(getKeyStoreFile()));
-			keyStore.setPassword(getKeyStorePassword());
-			ssl.setKeyStore(keyStore);
-		}
-
-		return ssl;
-	}
-
-	/**
-	 * Build the Proxy Req bean for the request builder
-	 * 
-	 * @return The Proxy Req according to the input values
-	 */
-	private Proxy buildProxy() {
-		final Proxy proxy = new Proxy();
-		proxy.setProtocol(ProxyProtocol.valueOf(getProxyProtocol().toUpperCase()));
-		proxy.setHost(getProxyHost());
-		proxy.setPort(getProxyPort());
-
-		if (isStringInputValid(getProxyUsername())) {
-			proxy.setUsername(getProxyUsername());
-		}
-
-		if (isStringInputValid(getProxyPassword())) {
-			proxy.setPassword(getProxyPassword());
-		}
-
-		return proxy;
-	}
-
-	/**
-	 * Extracts the response of the HTTP transaction
-	 * 
-	 * @param response The response of the sent request
-	 * @param request
-	 * @throws
-	 * @throws IOException
-	 */
-	private void setOutputs(final HttpResponse response, Request request) throws IOException {
-		if (response != null) {
-			final HttpEntity entity = response.getEntity();
-			if (entity != null) {
-				if (request.isIgnore()) {
-					EntityUtils.consumeQuietly(entity);
-				} else {
-					parseResponse(entity);
-				}
-			} else {
-				setBody("");
-				setBody(Collections.<String, Object>emptyMap());
-			}
-			setHeaders(asMap(response.getAllHeaders()));
-			setStatusCode(response.getStatusLine().getStatusCode());
-			setStatusMessage(response.getStatusLine().getReasonPhrase());
-			LOGGER.fine("All outputs have been set.");
-		} else {
-			LOGGER.fine("Response is null.");
-		}
-	}
-
-	private void parseResponse(final HttpEntity entity) throws IOException {
-		boolean fallbackToDefaultCharset = Boolean
-				.parseBoolean(System.getProperty(DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY));
-		String stringContent = EntityUtils.toString(entity, fallbackToDefaultCharset ? Charset.defaultCharset() : null);
-		final String bodyResponse = stringContent != null ? stringContent.trim() : "";
-		setBody(bodyResponse);
-		setBody(Collections.<String, Object>emptyMap());
-		ContentType contentType = ContentType.get(entity);
-		if (contentType != null && ContentType.APPLICATION_JSON.getMimeType().equals(contentType.getMimeType())) {
-			try {
-				if (bodyResponse.startsWith("[")) {
-					setBody(new ObjectMapper().readValue(bodyResponse, List.class));
-				} else if (bodyResponse.startsWith("{")) {
-					setBody(new ObjectMapper().readValue(bodyResponse, HashMap.class));
-				} else {
-					setBody(new ObjectMapper().readValue(bodyResponse, Object.class));
-				}
-			} catch (JsonParseException | JsonMappingException e) {
-				LOGGER.warning(String.format(
-						"BodyAsObject output cannot be set. Response content is not valid json(%s).", bodyResponse));
-			}
-		} else {
-			LOGGER.warning(() -> String.format(
-					"Body as map output cannot be set. Response content type is not json compliant(%s).",
-					contentType != null ? contentType : "no Content-Type in response header"));
-		}
-	}
-
-	private Map<String, String> asMap(Header[] headers) {
-		final Map<String, String> result = new HashMap<>();
-		if (headers != null) {
-			for (final Header header : headers) {
-				String name = header.getName();
-				if (!result.containsKey(name)) {
-					result.put(name, header.getValue());
-				} else {
-					String currentValue = result.get(name);
-					if (header.getValue() != null && !header.getValue().isEmpty())
-						result.put(name, currentValue + ";" + header.getValue());
-				}
-			}
-		}
-		return result;
-	}
-
-	/**
-	 * Execute a given request
-	 * 
-	 * @param request The request to execute
-	 * @throws Exception any exception that might occur
-	 */
-	public void execute(final Request request) throws Exception {
-		CloseableHttpClient httpClient = null;
-
-		try {
-			final URL url = request.getUrl();
-			final String urlHost = url.getHost();
-
-			final Builder requestConfigurationBuilder = RequestConfig.custom();
-			requestConfigurationBuilder.setConnectionRequestTimeout(getConnectionTimeoutMs());
-			requestConfigurationBuilder.setRedirectsEnabled(request.isRedirect());
-			requestConfigurationBuilder.setConnectTimeout(getConnectionTimeoutMs());
-			requestConfigurationBuilder.setSocketTimeout(getSocketTimeoutMs());
-
-			final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-			httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
-			setSSL(request.getSsl(), httpClientBuilder);
-			setProxy(request.getProxy(), httpClientBuilder, requestConfigurationBuilder);
-			setCookies(requestConfigurationBuilder, httpClientBuilder, request.getCookies(), urlHost);
-
-			final RequestBuilder requestBuilder = getRequestBuilderFromMethod(request.getRestMethod());
-			requestBuilder.setVersion(
-					new ProtocolVersion(HTTP_PROTOCOL, HTTP_PROTOCOL_VERSION_MAJOR, HTTP_PROTOCOL_VERSION_MINOR));
-			int urlPort = url.getPort();
-			if (url.getPort() == -1) {
-				urlPort = url.getDefaultPort();
-			}
-			final String urlProtocol = url.getProtocol();
-			final String urlStr = url.toString();
-			requestBuilder.setUri(urlStr);
-			setHeaders(requestBuilder, request.getHeaders());
-			if (!HTTPMethod.GET.equals(HTTPMethod.valueOf(requestBuilder.getMethod()))) {
-				final String body = request.getBody();
-				if (body != null) {
-					requestBuilder.setEntity(new StringEntity(request.getBody(), request.getContentType()));
-				}
-			}
-
-			final HttpContext httpContext = setAuthorizations(requestConfigurationBuilder, request.getAuthorization(),
-					request.getProxy(), urlHost, urlPort, urlProtocol, httpClientBuilder);
-
-			requestBuilder.setConfig(requestConfigurationBuilder.build());
-			httpClientBuilder.setDefaultRequestConfig(requestConfigurationBuilder.build());
-
-			final HttpUriRequest httpRequest = requestBuilder.build();
-			httpClient = httpClientBuilder.build();
-			LOGGER.fine("Request sent.");
-			final CloseableHttpResponse httpResponse = httpClient.execute(httpRequest, httpContext);
-			LOGGER.fine("Response recieved.");
-			final int statusCode = httpResponse.getStatusLine().getStatusCode();
-			if (!statusSuccessful(statusCode)) {
-				LOGGER.warning(() -> String.format("%s response status is not successful: %s - %s", request, statusCode,
-						httpResponse.getStatusLine().getReasonPhrase()));
-			}
-			setOutputs(httpResponse, request);
-		} finally {
-			try {
-				if (httpClient != null) {
-					httpClient.close();
-				}
-			} catch (final IOException ex) {
-				logException(ex);
-			}
-		}
-	}
-
-	private boolean statusSuccessful(int statusCode) {
-		return statusCode >= 200 && statusCode < 400;
-	}
-
-	/**
-	 * Set the request builder based on the request
-	 * 
-	 * @param ssl               The request SSL options
-	 * @param httpClientBuilder The request builder
-	 * @throws Exception
-	 */
-	private void setSSL(final SSL ssl, final HttpClientBuilder httpClientBuilder) throws Exception {
-		if (ssl != null) {
-			final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
-			TrustCertificateStrategy trustCertificateStrategy = ssl.getTrustCertificateStrategy();
-			if (trustCertificateStrategy == TrustCertificateStrategy.TRUST_SELF_SIGNED) {
-				sslContextBuilder.loadTrustMaterial(null, TrustSelfSignedStrategy.INSTANCE);
-			}else if(trustCertificateStrategy == TrustCertificateStrategy.TRUST_ALL) {
-				sslContextBuilder.loadTrustMaterial(null, new TrustStrategy() {
-					@Override
-					public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-						return Boolean.TRUE;
-					}
-				});
-			}
-			if (ssl.getTrustStore() != null) {
-				final KeyStore keyStore = ssl.getTrustStore().generateKeyStore();
-				if (trustCertificateStrategy == TrustCertificateStrategy.DEFAULT) {
-					sslContextBuilder.loadTrustMaterial(keyStore, null);
-				}
-			}
-
-			if (ssl.getKeyStore() != null) {
-				final KeyStore keyStore = ssl.getKeyStore().generateKeyStore();
-				final String keyStorePassword = ssl.getKeyStore().getPassword();
-				sslContextBuilder.loadKeyMaterial(keyStore, keyStorePassword.toCharArray());
-			}
-
-			sslContextBuilder.setSecureRandom(null);
-			sslContextBuilder.useProtocol(ssl.isUseTLS() ? "TLS" : "SSL");
-
-			final SSLVerifier verifier = ssl.getSslVerifier();
-			HostnameVerifier hostnameVerifier = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
-			switch (verifier) {
-			case ALLOW:
-				hostnameVerifier = NoopHostnameVerifier.INSTANCE;
-				break;
-			case BROWSER:
-				hostnameVerifier = BrowserCompatHostnameVerifier.INSTANCE;
-				break;
-			case STRICT:
-			default:
-				break;
-			}
-
-			final SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContextBuilder.build(),
-					hostnameVerifier);
-			httpClientBuilder.setSSLSocketFactory(socketFactory);
-		}
-	}
-
-	/**
-	 * Set the request builder based on the request
-	 * 
-	 * @param proxy             The request Proxy options
-	 * @param httpClientBuilder The request builder
-	 * @throws Exception
-	 */
-	private void setProxy(final Proxy proxy, final HttpClientBuilder httpClientBuilder,
-			final Builder requestConfigurationBuilder) {
-		if (proxy != null) {
-			final HttpHost httpHost = new HttpHost(proxy.getHost(), proxy.getPort());
-
-			httpClientBuilder.setProxy(httpHost);
-			httpClientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
-
-			requestConfigurationBuilder.setProxy(httpHost);
-			final ArrayList<String> authPrefs = new ArrayList<>();
-			authPrefs.add(AuthSchemes.BASIC);
-			requestConfigurationBuilder.setProxyPreferredAuthSchemes(authPrefs);
-		}
-	}
-
-	/**
-	 * Set the request builder credentials provider based on the request
-	 * 
-	 * @param proxy               The request Proxy options
-	 * @param credentialsProvider The request builder credentials provider
-	 */
-	private void setProxyCrendentials(final Proxy proxy, final CredentialsProvider credentialsProvider) {
-		if (proxy != null && proxy.hasCredentials()) {
-			credentialsProvider.setCredentials(new AuthScope(proxy.getHost(), proxy.getPort()),
-					new UsernamePasswordCredentials(proxy.getUsername(),
-							proxy.getPassword() == null ? "" : proxy.getPassword()));
-		}
-	}
-
-	/**
-	 * Set the cookies to the builder based on the request cookies
-	 * 
-	 * @param requestConfigurationBuilder The request builder
-	 * @param httpClientBuilder           The request builder
-	 * @param list                        The cookies
-	 * @param urlHost                     The URL host
-	 */
-	private void setCookies(final Builder requestConfigurationBuilder, final HttpClientBuilder httpClientBuilder,
-			final List<HttpCookie> list, final String urlHost) {
-		final CookieStore cookieStore = new BasicCookieStore();
-		final List<HttpCookie> cookies = list;
-		for (final HttpCookie cookie : cookies) {
-			final BasicClientCookie c = new BasicClientCookie(cookie.getName(), cookie.getValue());
-			c.setPath("/");
-			c.setVersion(0);
-			c.setDomain(urlHost);
-			cookieStore.addCookie(c);
-		}
-		httpClientBuilder.setDefaultCookieStore(cookieStore);
-		requestConfigurationBuilder.setCookieSpec(CookieSpecs.BEST_MATCH);
-	}
-
-	/**
-	 * Set the headers to the builder based on the request headers
-	 * 
-	 * @param requestBuilder The request builder
-	 * @param headerData     The request headers
-	 */
-	private void setHeaders(final RequestBuilder requestBuilder, final List<Header> headerData) {
-		for (final Header aHeaderData : headerData) {
-			requestBuilder.addHeader(aHeaderData);
-		}
-	}
-
-	/**
-	 * Set the builder based on the request elements
-	 * 
-	 * @param requestConfigurationBuilder The builder to be set
-	 * @param authorization               The authentication element of the request
-	 * @param proxy                       The proxy element of the request
-	 * @param urlHost                     The URL host of the request
-	 * @param urlPort                     The URL post of the request
-	 * @param urlProtocol                 The URL protocol of the request
-	 * @param httpClientBuilder           The builder to be set
-	 * @return HTTPContext The HTTP context to be set
-	 */
-	private HttpContext setAuthorizations(final Builder requestConfigurationBuilder, final Authorization authorization,
-			final Proxy proxy, final String urlHost, final int urlPort, final String urlProtocol,
-			final HttpClientBuilder httpClientBuilder) {
-		HttpContext httpContext = HttpClientContext.create();
-		if (authorization != null) {
-			if (authorization instanceof BasicDigestAuthorization) {
-				final BasicDigestAuthorization castAuthorization = (BasicDigestAuthorization) authorization;
-
-				final List<String> authPrefs = new ArrayList<>();
-				authPrefs.add(castAuthorization.isBasic() ? AuthSchemes.BASIC : AuthSchemes.DIGEST);
-				requestConfigurationBuilder.setTargetPreferredAuthSchemes(authPrefs);
-				final String username = castAuthorization.getUsername();
-				final String password = new String(castAuthorization.getPassword());
-				String host = urlHost;
-				if (isStringInputValid(castAuthorization.getHost())) {
-					host = castAuthorization.getHost();
-				}
-
-				int port = urlPort;
-				if (castAuthorization.getPort() != null) {
-					port = castAuthorization.getPort();
-				}
-
-				String realm = AuthScope.ANY_REALM;
-				if (isStringInputValid(castAuthorization.getRealm())) {
-					realm = castAuthorization.getRealm();
-				}
-
-				final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-				credentialsProvider.setCredentials(new AuthScope(host, port, realm),
-						new UsernamePasswordCredentials(username, password));
-				setProxyCrendentials(proxy, credentialsProvider);
-				httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-
-				if (castAuthorization.isPreemptive() || proxy != null) {
-					final AuthCache authenticationCache = new BasicAuthCache();
-					if (castAuthorization.isPreemptive()) {
-						final AuthSchemeBase authorizationScheme = castAuthorization.isBasic() ? new BasicScheme()
-								: new DigestScheme();
-						authenticationCache.put(new HttpHost(host, port, urlProtocol), authorizationScheme);
-					}
-					if (proxy != null) {
-						final BasicScheme basicScheme = new BasicScheme(ChallengeState.PROXY);
-						authenticationCache.put(new HttpHost(proxy.getHost(), proxy.getPort()), basicScheme);
-					}
-					final HttpClientContext localContext = HttpClientContext.create();
-					localContext.setAuthCache(authenticationCache);
-					httpContext = localContext;
-				}
-			}
-		} else if (proxy != null) {
-			final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-			setProxyCrendentials(proxy, credentialsProvider);
-			httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-
-			// Make it preemptive
-			if (proxy.hasCredentials()) {
-				final AuthCache authoriationCache = new BasicAuthCache();
-				final BasicScheme basicScheme = new BasicScheme(ChallengeState.PROXY);
-				authoriationCache.put(new HttpHost(proxy.getHost(), proxy.getPort()), basicScheme);
-				final HttpClientContext localContext = HttpClientContext.create();
-				localContext.setAuthCache(authoriationCache);
-				httpContext = localContext;
-			}
-		}
-
-		return httpContext;
-	}
-
-	/**
-	 * Generate a request builder based on the given method
-	 * 
-	 * @param method The method
-	 * @return The request builder
-	 */
-	private RequestBuilder getRequestBuilderFromMethod(final HTTPMethod method) {
-		switch (method) {
-		case GET:
-			return RequestBuilder.get();
-		case POST:
-			return RequestBuilder.post();
-		case PUT:
-			return RequestBuilder.put();
-		case DELETE:
-			return RequestBuilder.delete();
-		default:
-			throw new IllegalStateException(
-					"Impossible to get the RequestBuilder from the \"" + method.name() + "\" name.");
-		}
-	}
-
-	/**
-	 * Log an exception in generic way
-	 * 
-	 * @param e The exception raised
-	 * @throws ConnectorException The connector exception for the BonitaSoft system
-	 *                            to act from it
-	 */
-	private void logException(final Exception e) {
-		final StringBuffer stringBuffer = new StringBuffer();
-		stringBuffer.append(e.toString());
-		for (final StackTraceElement stackTraceElement : e.getStackTrace()) {
-			stringBuffer.append("\n" + stackTraceElement);
-		}
-		LOGGER.fine("executeBusinessLogic error: " + stringBuffer.toString());
-	}
-
+  /** The HTTP request builder constants. */
+  private static final String HTTP_PROTOCOL = "HTTP";
+
+  private static final int HTTP_PROTOCOL_VERSION_MAJOR = 1;
+  private static final int HTTP_PROTOCOL_VERSION_MINOR = 1;
+
+  /** The class logger */
+  private static final Logger LOGGER = Logger.getLogger(RESTConnector.class.getName());
+  /**
+   * Forces the character encoding of the HTTP response body to the default JVM Charset if no
+   * Charset is defined in the response header. If this property is not set, the ISO-8859-1 Charset
+   * is used as fallback, as specified in the specification.
+   */
+  static final String DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY =
+      "org.bonitasoft.connectors.rest.response.fallbackToJVMCharset";
+
+  @Override
+  public void validateInputParameters() throws ConnectorValidationException {
+    super.validateInputParameters();
+
+    LOGGER.fine("super validateInputParameters done.");
+
+    final List<String> messages = new ArrayList<>(0);
+    if (!isStringInputValid(getUrl())) {
+      messages.add(URL_INPUT_PARAMETER);
+    } else {
+      try {
+        new URL(getUrl());
+      } catch (final MalformedURLException e) {
+        messages.add(URL_INPUT_PARAMETER);
+      }
+    }
+
+    if (!isStringInputValid(getMethod())) {
+      messages.add(METHOD_INPUT_PARAMETER);
+    }
+
+    if (Objects.equals(getMethod(), HTTPMethod.POST.name())
+        || Objects.equals(getMethod(), HTTPMethod.PUT.name())) {
+      if (!isStringInputValid(getContentType())) {
+        messages.add(CONTENTTYPE_INPUT_PARAMETER);
+      }
+      if (!isStringInputValid(getCharset())) {
+        messages.add(CHARSET_INPUT_PARAMETER);
+      }
+    }
+
+    final List<?> urlCookies = getUrlCookies();
+    messages.addAll(manageKeyValueCouples(urlCookies, URLCOOKIES_INPUT_PARAMETER));
+
+    final List<?> urlheaders = getUrlHeaders();
+    messages.addAll(manageKeyValueCouples(urlheaders, URLHEADERS_INPUT_PARAMETER));
+
+    if (!messages.isEmpty()) {
+      LOGGER.fine(() -> String.format("validateInputParameters error: %s", messages.toString()));
+      throw new ConnectorValidationException(this, messages);
+    }
+  }
+
+  /**
+   * Is the String input valid?
+   *
+   * @param value The value to be checked
+   * @return If the String input is valid or not
+   */
+  private boolean isStringInputValid(final String value) {
+    return value != null && !value.isEmpty();
+  }
+
+  /**
+   * Validate the key value couples
+   *
+   * @param keyValueCouples The key value couples from the input
+   * @param inputName The input name where the key value couples are from
+   * @return The error messages if any or empty list otherwise
+   */
+  private List<String> manageKeyValueCouples(
+      final List<?> keyValueCouples, final String inputName) {
+    final List<String> messages = new ArrayList<>();
+    if (keyValueCouples == null) {
+      return messages;
+    }
+    for (final Object keyValueCouple : keyValueCouples) {
+      if (keyValueCouple instanceof List) {
+        final List<?> keyValueCoupleRow = (List<?>) keyValueCouple;
+        if (!isItAKeyValueCouple(keyValueCoupleRow)) {
+          messages.add(inputName + " - columns - " + keyValueCoupleRow.size());
+        } else if (!isKeyValueCoupleValid(keyValueCoupleRow)) {
+          messages.add(inputName + " - value");
+        }
+      } else {
+        messages.add(inputName + " - type");
+      }
+    }
+    return messages;
+  }
+
+  /**
+   * Is the key and the value valid?
+   *
+   * @param keyValueCoupleRow The key value couple row
+   * @return If the key and the value is valid or not
+   */
+  private boolean isKeyValueCoupleValid(final List<?> keyValueCoupleRow) {
+    return keyValueCoupleRow.get(0) != null
+        && !keyValueCoupleRow.get(0).toString().isEmpty()
+        && keyValueCoupleRow.get(1) != null;
+  }
+
+  /**
+   * Is the row a key value couple?
+   *
+   * @param keyValueCoupleRow the list of elements stating the row
+   * @return If the row is a key value couple or not
+   */
+  private boolean isItAKeyValueCouple(final List<?> keyValueCoupleRow) {
+    return keyValueCoupleRow.size() == 2;
+  }
+
+  @Override
+  protected void executeBusinessLogic() throws ConnectorException {
+    try {
+      final Request request = buildRequest();
+      execute(request);
+    } catch (final Exception e) {
+      logException(e);
+      throw new ConnectorException(e);
+    }
+  }
+
+  /**
+   * Build the request bean from all the inputs
+   *
+   * @return The request bean
+   * @throws MalformedURLException
+   */
+  private Request buildRequest() throws MalformedURLException, ConnectorException {
+    final Request request = new Request();
+    request.setUrl(new URL(getUrl()));
+    LOGGER.fine("URL set to: " + request.getUrl().toString());
+    request.setRestMethod(HTTPMethod.getRESTHTTPMethodFromValue(getMethod()));
+    if (request.getRestMethod() == HTTPMethod.POST || request.getRestMethod() == HTTPMethod.PUT) {
+      request.setContentType(ContentType.create(getContentType(), Charset.forName(getCharset())));
+    }
+    LOGGER.fine("Method set to: " + request.getRestMethod().toString());
+    setBody(request);
+    LOGGER.fine("Body set to: " + request.getBody().toString());
+    request.setRedirect(!getDoNotFollowRedirect());
+    LOGGER.fine("Follow redirect set to: " + request.isRedirect());
+    request.setIgnore(getIgnoreBody());
+    LOGGER.fine("Ignore body set to: " + request.isIgnore());
+    for (final Object urlheader : getUrlHeaders()) {
+      final List<?> urlheaderRow = (List<?>) urlheader;
+      String name = urlheaderRow.get(0).toString();
+      String value = urlheaderRow.get(1).toString();
+      request.addHeader(name, value);
+      LOGGER.fine(
+          "Add header: "
+              + urlheaderRow.get(0).toString()
+              + " set as "
+              + urlheaderRow.get(1).toString());
+    }
+    for (final Object urlCookie : getUrlCookies()) {
+      final List<?> urlCookieRow = (List<?>) urlCookie;
+      request.addCookie(urlCookieRow.get(0).toString(), urlCookieRow.get(1).toString());
+      LOGGER.fine(
+          "Add cookie: "
+              + urlCookieRow.get(0).toString()
+              + " set as "
+              + urlCookieRow.get(1).toString());
+    }
+
+    request.setSsl(buildSSL());
+    LOGGER.fine("Add the SSL options");
+
+    if (isProxySet()) {
+      request.setProxy(buildProxy());
+      LOGGER.fine("Add the Proxy options");
+    }
+
+    if (getAuthType() == AuthorizationType.BASIC) {
+      LOGGER.fine("Add basic auth");
+      request.setAuthorization(buildBasicAuthorization());
+    } else if (getAuthType() == AuthorizationType.DIGEST) {
+      LOGGER.fine("Add digest auth");
+      request.setAuthorization(buildDigestAuthorization());
+    }
+    return request;
+  }
+
+  private void setBody(Request request) throws ConnectorException {
+    if (getBody() != null) {
+      Serializable body = getBody();
+      if (body instanceof Document) {
+        Document doc = (Document) body;
+        try {
+          request.setBody(
+              getAPIAccessor().getProcessAPI().getDocumentContent(doc.getContentStorageId()));
+        } catch (DocumentNotFoundException e) {
+          throw new ConnectorException("Document not found", e);
+        }
+      } else {
+        request.setBody(body);
+      }
+    } else {
+      request.setBody("");
+    }
+  }
+
+  /**
+   * Is a Proxy used?
+   *
+   * @return If a Proxy is used or not
+   */
+  private boolean isProxySet() {
+    return isStringInputValid(getProxyHost()) && isStringInputValid(getProxyProtocol());
+  }
+
+  /**
+   * Build the Digest Auth bean for the request builder
+   *
+   * @return The Digest Auth according to the input values
+   */
+  private BasicDigestAuthorization buildDigestAuthorization() {
+    final BasicDigestAuthorization authorization = new BasicDigestAuthorization(false);
+    authorization.setUsername(getAuthUsername());
+    authorization.setPassword(getAuthPassword());
+
+    if (isStringInputValid(getAuthHost())) {
+      authorization.setHost(getAuthHost());
+    }
+    authorization.setPort(getAuthPort());
+    if (isStringInputValid(getAuthRealm())) {
+      authorization.setRealm(getAuthRealm());
+    }
+    authorization.setPreemptive(getAuthPreemptive());
+    return authorization;
+  }
+
+  /**
+   * Build the Basic Auth bean for the request builder
+   *
+   * @return The Basic Auth according to the input values
+   */
+  private BasicDigestAuthorization buildBasicAuthorization() {
+    final BasicDigestAuthorization authorization = new BasicDigestAuthorization(true);
+    authorization.setUsername(getAuthUsername());
+    authorization.setPassword(getAuthPassword());
+
+    if (isStringInputValid(getAuthHost())) {
+      authorization.setHost(getAuthHost());
+    }
+    authorization.setPort(getAuthPort());
+    if (isStringInputValid(getAuthRealm())) {
+      authorization.setRealm(getAuthRealm());
+    }
+    authorization.setPreemptive(getAuthPreemptive());
+
+    return authorization;
+  }
+
+  /**
+   * Build the SSL Req bean for the request builder
+   *
+   * @return The SSL Req according to the input values
+   */
+  private SSL buildSSL() {
+    final SSL ssl = new SSL();
+    ssl.setSslVerifier(getHostnameVerifier());
+    ssl.setTrustCertificateStrategy(getTrustCertificateStrategy());
+    ssl.setUseTLS(getTLS());
+
+    if (isStringInputValid(getTrustStoreFile()) && isStringInputValid(getTrustStorePassword())) {
+      final Store trustStore = new Store();
+      trustStore.setFile(new File(getTrustStoreFile()));
+      trustStore.setPassword(getTrustStorePassword());
+      ssl.setTrustStore(trustStore);
+    }
+
+    if (isStringInputValid(getKeyStoreFile()) && isStringInputValid(getKeyStorePassword())) {
+      final Store keyStore = new Store();
+      keyStore.setFile(new File(getKeyStoreFile()));
+      keyStore.setPassword(getKeyStorePassword());
+      ssl.setKeyStore(keyStore);
+    }
+
+    return ssl;
+  }
+
+  /**
+   * Build the Proxy Req bean for the request builder
+   *
+   * @return The Proxy Req according to the input values
+   */
+  private Proxy buildProxy() {
+    final Proxy proxy = new Proxy();
+    proxy.setProtocol(ProxyProtocol.valueOf(getProxyProtocol().toUpperCase()));
+    proxy.setHost(getProxyHost());
+    proxy.setPort(getProxyPort());
+
+    if (isStringInputValid(getProxyUsername())) {
+      proxy.setUsername(getProxyUsername());
+    }
+
+    if (isStringInputValid(getProxyPassword())) {
+      proxy.setPassword(getProxyPassword());
+    }
+
+    return proxy;
+  }
+
+  /**
+   * Extracts the response of the HTTP transaction
+   *
+   * @param response The response of the sent request
+   * @param request
+   * @throws
+   * @throws IOException
+   */
+  private void setOutputs(final HttpResponse response, Request request) throws IOException {
+    if (response != null) {
+      final HttpEntity entity = response.getEntity();
+      if (entity != null) {
+        if (request.isIgnore()) {
+          EntityUtils.consumeQuietly(entity);
+        } else {
+          parseResponse(entity);
+        }
+      } else {
+        setBody("");
+        setBody(Collections.<String, Object>emptyMap());
+      }
+      setHeaders(asMap(response.getAllHeaders()));
+      setStatusCode(response.getStatusLine().getStatusCode());
+      setStatusMessage(response.getStatusLine().getReasonPhrase());
+      LOGGER.fine("All outputs have been set.");
+    } else {
+      LOGGER.fine("Response is null.");
+    }
+  }
+
+  private void parseResponse(final HttpEntity entity) throws IOException {
+    boolean fallbackToDefaultCharset =
+        Boolean.parseBoolean(System.getProperty(DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY));
+    String stringContent =
+        EntityUtils.toString(entity, fallbackToDefaultCharset ? Charset.defaultCharset() : null);
+    final String bodyResponse = stringContent != null ? stringContent.trim() : "";
+    setBody(bodyResponse);
+    setBody(Collections.<String, Object>emptyMap());
+    ContentType contentType = ContentType.get(entity);
+    if (contentType != null
+        && ContentType.APPLICATION_JSON.getMimeType().equals(contentType.getMimeType())) {
+      try {
+        if (bodyResponse.startsWith("[")) {
+          setBody(new ObjectMapper().readValue(bodyResponse, List.class));
+        } else if (bodyResponse.startsWith("{")) {
+          setBody(new ObjectMapper().readValue(bodyResponse, HashMap.class));
+        } else {
+          setBody(new ObjectMapper().readValue(bodyResponse, Object.class));
+        }
+      } catch (JsonParseException | JsonMappingException e) {
+        LOGGER.warning(
+            String.format(
+                "BodyAsObject output cannot be set. Response content is not valid json(%s).",
+                bodyResponse));
+      }
+    } else {
+      LOGGER.warning(
+          () ->
+              String.format(
+                  "Body as map output cannot be set. Response content type is not json compliant(%s).",
+                  contentType != null ? contentType : "no Content-Type in response header"));
+    }
+  }
+
+  private Map<String, String> asMap(Header[] headers) {
+    final Map<String, String> result = new HashMap<>();
+    if (headers != null) {
+      for (final Header header : headers) {
+        String name = header.getName();
+        if (!result.containsKey(name)) {
+          result.put(name, header.getValue());
+        } else {
+          String currentValue = result.get(name);
+          if (header.getValue() != null && !header.getValue().isEmpty())
+            result.put(name, currentValue + ";" + header.getValue());
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Execute a given request
+   *
+   * @param request The request to execute
+   * @throws Exception any exception that might occur
+   */
+  public void execute(final Request request) throws Exception {
+    CloseableHttpClient httpClient = null;
+
+    try {
+      final URL url = request.getUrl();
+      final String urlHost = url.getHost();
+
+      final Builder requestConfigurationBuilder = RequestConfig.custom();
+      requestConfigurationBuilder.setConnectionRequestTimeout(getConnectionTimeoutMs());
+      requestConfigurationBuilder.setRedirectsEnabled(request.isRedirect());
+      requestConfigurationBuilder.setConnectTimeout(getConnectionTimeoutMs());
+      requestConfigurationBuilder.setSocketTimeout(getSocketTimeoutMs());
+
+      final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+      httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
+      setSSL(request.getSsl(), httpClientBuilder);
+      setProxy(request.getProxy(), httpClientBuilder, requestConfigurationBuilder);
+      setCookies(requestConfigurationBuilder, httpClientBuilder, request.getCookies(), urlHost);
+
+      final RequestBuilder requestBuilder = getRequestBuilderFromMethod(request.getRestMethod());
+      requestBuilder.setVersion(
+          new ProtocolVersion(
+              HTTP_PROTOCOL, HTTP_PROTOCOL_VERSION_MAJOR, HTTP_PROTOCOL_VERSION_MINOR));
+      int urlPort = url.getPort();
+      if (url.getPort() == -1) {
+        urlPort = url.getDefaultPort();
+      }
+      final String urlProtocol = url.getProtocol();
+      final String urlStr = url.toString();
+      requestBuilder.setUri(urlStr);
+      setHeaders(requestBuilder, request.getHeaders());
+      if (!HTTPMethod.GET.equals(HTTPMethod.valueOf(requestBuilder.getMethod()))) {
+        final Serializable body = request.getBody();
+        if (body != null) {
+          ContentType contentType =
+              ContentType.create(getContentType(), Charset.forName(getCharset()));
+          requestBuilder.setEntity(
+              new ByteArrayEntity(toByteArray(body, contentType.getCharset()), contentType));
+        }
+      }
+
+      final HttpContext httpContext =
+          setAuthorizations(
+              requestConfigurationBuilder,
+              request.getAuthorization(),
+              request.getProxy(),
+              urlHost,
+              urlPort,
+              urlProtocol,
+              httpClientBuilder);
+
+      requestBuilder.setConfig(requestConfigurationBuilder.build());
+      httpClientBuilder.setDefaultRequestConfig(requestConfigurationBuilder.build());
+
+      final HttpUriRequest httpRequest = requestBuilder.build();
+      httpClient = httpClientBuilder.build();
+      LOGGER.fine("Request sent.");
+      final CloseableHttpResponse httpResponse = httpClient.execute(httpRequest, httpContext);
+      LOGGER.fine("Response recieved.");
+      final int statusCode = httpResponse.getStatusLine().getStatusCode();
+      if (!statusSuccessful(statusCode)) {
+        LOGGER.warning(
+            () ->
+                String.format(
+                    "%s response status is not successful: %s - %s",
+                    request, statusCode, httpResponse.getStatusLine().getReasonPhrase()));
+      }
+      setOutputs(httpResponse, request);
+    } finally {
+      try {
+        if (httpClient != null) {
+          httpClient.close();
+        }
+      } catch (final IOException ex) {
+        logException(ex);
+      }
+    }
+  }
+
+  private byte[] toByteArray(Serializable body, Charset charset) {
+    if (body instanceof String) {
+      return ((String) body).getBytes(charset);
+    }
+    if (body instanceof byte[]) {
+      return (byte[]) body;
+    }
+    throw new IllegalArgumentException(
+        "Body content type not supported. Expected String or byte[]");
+  }
+
+  private boolean statusSuccessful(int statusCode) {
+    return statusCode >= 200 && statusCode < 400;
+  }
+
+  /**
+   * Set the request builder based on the request
+   *
+   * @param ssl The request SSL options
+   * @param httpClientBuilder The request builder
+   * @throws Exception
+   */
+  private void setSSL(final SSL ssl, final HttpClientBuilder httpClientBuilder) throws Exception {
+    if (ssl != null) {
+      final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+      TrustCertificateStrategy trustCertificateStrategy = ssl.getTrustCertificateStrategy();
+      if (trustCertificateStrategy == TrustCertificateStrategy.TRUST_SELF_SIGNED) {
+        sslContextBuilder.loadTrustMaterial(null, TrustSelfSignedStrategy.INSTANCE);
+      } else if (trustCertificateStrategy == TrustCertificateStrategy.TRUST_ALL) {
+        sslContextBuilder.loadTrustMaterial(
+            null,
+            new TrustStrategy() {
+              @Override
+              public boolean isTrusted(X509Certificate[] chain, String authType)
+                  throws CertificateException {
+                return Boolean.TRUE;
+              }
+            });
+      }
+      if (ssl.getTrustStore() != null) {
+        final KeyStore keyStore = ssl.getTrustStore().generateKeyStore();
+        if (trustCertificateStrategy == TrustCertificateStrategy.DEFAULT) {
+          sslContextBuilder.loadTrustMaterial(keyStore, null);
+        }
+      }
+
+      if (ssl.getKeyStore() != null) {
+        final KeyStore keyStore = ssl.getKeyStore().generateKeyStore();
+        final String keyStorePassword = ssl.getKeyStore().getPassword();
+        sslContextBuilder.loadKeyMaterial(keyStore, keyStorePassword.toCharArray());
+      }
+
+      sslContextBuilder.setSecureRandom(null);
+      sslContextBuilder.useProtocol(ssl.isUseTLS() ? "TLS" : "SSL");
+
+      final SSLVerifier verifier = ssl.getSslVerifier();
+      HostnameVerifier hostnameVerifier = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+      switch (verifier) {
+        case ALLOW:
+          hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+          break;
+        case BROWSER:
+          hostnameVerifier = BrowserCompatHostnameVerifier.INSTANCE;
+          break;
+        case STRICT:
+        default:
+          break;
+      }
+
+      final SSLConnectionSocketFactory socketFactory =
+          new SSLConnectionSocketFactory(sslContextBuilder.build(), hostnameVerifier);
+      httpClientBuilder.setSSLSocketFactory(socketFactory);
+    }
+  }
+
+  /**
+   * Set the request builder based on the request
+   *
+   * @param proxy The request Proxy options
+   * @param httpClientBuilder The request builder
+   * @throws Exception
+   */
+  private void setProxy(
+      final Proxy proxy,
+      final HttpClientBuilder httpClientBuilder,
+      final Builder requestConfigurationBuilder) {
+    if (proxy != null) {
+      final HttpHost httpHost = new HttpHost(proxy.getHost(), proxy.getPort());
+
+      httpClientBuilder.setProxy(httpHost);
+      httpClientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+
+      requestConfigurationBuilder.setProxy(httpHost);
+      final ArrayList<String> authPrefs = new ArrayList<>();
+      authPrefs.add(AuthSchemes.BASIC);
+      requestConfigurationBuilder.setProxyPreferredAuthSchemes(authPrefs);
+    }
+  }
+
+  /**
+   * Set the request builder credentials provider based on the request
+   *
+   * @param proxy The request Proxy options
+   * @param credentialsProvider The request builder credentials provider
+   */
+  private void setProxyCrendentials(
+      final Proxy proxy, final CredentialsProvider credentialsProvider) {
+    if (proxy != null && proxy.hasCredentials()) {
+      credentialsProvider.setCredentials(
+          new AuthScope(proxy.getHost(), proxy.getPort()),
+          new UsernamePasswordCredentials(
+              proxy.getUsername(), proxy.getPassword() == null ? "" : proxy.getPassword()));
+    }
+  }
+
+  /**
+   * Set the cookies to the builder based on the request cookies
+   *
+   * @param requestConfigurationBuilder The request builder
+   * @param httpClientBuilder The request builder
+   * @param list The cookies
+   * @param urlHost The URL host
+   */
+  private void setCookies(
+      final Builder requestConfigurationBuilder,
+      final HttpClientBuilder httpClientBuilder,
+      final List<HttpCookie> list,
+      final String urlHost) {
+    final CookieStore cookieStore = new BasicCookieStore();
+    final List<HttpCookie> cookies = list;
+    for (final HttpCookie cookie : cookies) {
+      final BasicClientCookie c = new BasicClientCookie(cookie.getName(), cookie.getValue());
+      c.setPath("/");
+      c.setVersion(0);
+      c.setDomain(urlHost);
+      cookieStore.addCookie(c);
+    }
+    httpClientBuilder.setDefaultCookieStore(cookieStore);
+    requestConfigurationBuilder.setCookieSpec(CookieSpecs.BEST_MATCH);
+  }
+
+  /**
+   * Set the headers to the builder based on the request headers
+   *
+   * @param requestBuilder The request builder
+   * @param headerData The request headers
+   */
+  private void setHeaders(final RequestBuilder requestBuilder, final List<Header> headerData) {
+    for (final Header aHeaderData : headerData) {
+      requestBuilder.addHeader(aHeaderData);
+    }
+  }
+
+  /**
+   * Set the builder based on the request elements
+   *
+   * @param requestConfigurationBuilder The builder to be set
+   * @param authorization The authentication element of the request
+   * @param proxy The proxy element of the request
+   * @param urlHost The URL host of the request
+   * @param urlPort The URL post of the request
+   * @param urlProtocol The URL protocol of the request
+   * @param httpClientBuilder The builder to be set
+   * @return HTTPContext The HTTP context to be set
+   */
+  private HttpContext setAuthorizations(
+      final Builder requestConfigurationBuilder,
+      final Authorization authorization,
+      final Proxy proxy,
+      final String urlHost,
+      final int urlPort,
+      final String urlProtocol,
+      final HttpClientBuilder httpClientBuilder) {
+    HttpContext httpContext = HttpClientContext.create();
+    if (authorization != null) {
+      if (authorization instanceof BasicDigestAuthorization) {
+        final BasicDigestAuthorization castAuthorization = (BasicDigestAuthorization) authorization;
+
+        final List<String> authPrefs = new ArrayList<>();
+        authPrefs.add(castAuthorization.isBasic() ? AuthSchemes.BASIC : AuthSchemes.DIGEST);
+        requestConfigurationBuilder.setTargetPreferredAuthSchemes(authPrefs);
+        final String username = castAuthorization.getUsername();
+        final String password = new String(castAuthorization.getPassword());
+        String host = urlHost;
+        if (isStringInputValid(castAuthorization.getHost())) {
+          host = castAuthorization.getHost();
+        }
+
+        int port = urlPort;
+        if (castAuthorization.getPort() != null) {
+          port = castAuthorization.getPort();
+        }
+
+        String realm = AuthScope.ANY_REALM;
+        if (isStringInputValid(castAuthorization.getRealm())) {
+          realm = castAuthorization.getRealm();
+        }
+
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+            new AuthScope(host, port, realm), new UsernamePasswordCredentials(username, password));
+        setProxyCrendentials(proxy, credentialsProvider);
+        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+
+        if (castAuthorization.isPreemptive() || proxy != null) {
+          final AuthCache authenticationCache = new BasicAuthCache();
+          if (castAuthorization.isPreemptive()) {
+            final AuthSchemeBase authorizationScheme =
+                castAuthorization.isBasic() ? new BasicScheme() : new DigestScheme();
+            authenticationCache.put(new HttpHost(host, port, urlProtocol), authorizationScheme);
+          }
+          if (proxy != null) {
+            final BasicScheme basicScheme = new BasicScheme(ChallengeState.PROXY);
+            authenticationCache.put(new HttpHost(proxy.getHost(), proxy.getPort()), basicScheme);
+          }
+          final HttpClientContext localContext = HttpClientContext.create();
+          localContext.setAuthCache(authenticationCache);
+          httpContext = localContext;
+        }
+      }
+    } else if (proxy != null) {
+      final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+      setProxyCrendentials(proxy, credentialsProvider);
+      httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+
+      // Make it preemptive
+      if (proxy.hasCredentials()) {
+        final AuthCache authoriationCache = new BasicAuthCache();
+        final BasicScheme basicScheme = new BasicScheme(ChallengeState.PROXY);
+        authoriationCache.put(new HttpHost(proxy.getHost(), proxy.getPort()), basicScheme);
+        final HttpClientContext localContext = HttpClientContext.create();
+        localContext.setAuthCache(authoriationCache);
+        httpContext = localContext;
+      }
+    }
+
+    return httpContext;
+  }
+
+  /**
+   * Generate a request builder based on the given method
+   *
+   * @param method The method
+   * @return The request builder
+   */
+  private RequestBuilder getRequestBuilderFromMethod(final HTTPMethod method) {
+    switch (method) {
+      case GET:
+        return RequestBuilder.get();
+      case POST:
+        return RequestBuilder.post();
+      case PUT:
+        return RequestBuilder.put();
+      case DELETE:
+        return RequestBuilder.delete();
+      default:
+        throw new IllegalStateException(
+            "Impossible to get the RequestBuilder from the \"" + method.name() + "\" name.");
+    }
+  }
+
+  /**
+   * Log an exception in generic way
+   *
+   * @param e The exception raised
+   * @throws ConnectorException The connector exception for the BonitaSoft system to act from it
+   */
+  private void logException(final Exception e) {
+    final StringBuffer stringBuffer = new StringBuffer();
+    stringBuffer.append(e.toString());
+    for (final StackTraceElement stackTraceElement : e.getStackTrace()) {
+      stringBuffer.append("\n" + stackTraceElement);
+    }
+    LOGGER.fine("executeBusinessLogic error: " + stringBuffer.toString());
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/Authorization.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/Authorization.java
@@ -1,6 +1,4 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * This interface reflects the information for an authorization.
- */
-public interface Authorization { }
+/** This interface reflects the information for an authorization. */
+public interface Authorization {}

--- a/src/main/java/org/bonitasoft/connectors/rest/model/AuthorizationType.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/AuthorizationType.java
@@ -1,8 +1,7 @@
 package org.bonitasoft.connectors.rest.model;
 
-
 public enum AuthorizationType {
-
-    NONE,BASIC,DIGEST;
-    
+  NONE,
+  BASIC,
+  DIGEST;
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/BasicDigestAuthorization.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/BasicDigestAuthorization.java
@@ -1,164 +1,161 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * This class reflects the information for a Basic or Digest authorization of a HTTP request.
- */
+/** This class reflects the information for a Basic or Digest authorization of a HTTP request. */
 public class BasicDigestAuthorization implements Authorization {
 
-    /**
-     * Is the authorization information for a Basic authorization.
-     */
-    private boolean basic = true;
-    
-    /**
-     * The username value.
-     */
-    private String username = null;
-    
-    /**
-     * The password value.
-     */
-    private String password = null;
-    
-    /**
-     * The host value.
-     */
-    private String host = null;
-    
-    /**
-     * The port value.
-     */
-    private Integer port = null;
-    
-    /**
-     * The realm value.
-     */
-    private String realm = null;
-    
-    /**
-     * Is this authorization preemptive.
-     */
-    private boolean isPreemptive = true;
+  /** Is the authorization information for a Basic authorization. */
+  private boolean basic = true;
 
-    /**
-     * Constructor setting if the authorization is a Basic typed one.
-     * Default Constructor.
-     * @param basic States if it is a Basic authorization.
-     */
-    public BasicDigestAuthorization(final boolean basic) {
-        this.basic = basic;
-    }
-    
-    /**
-     * Username value getter.
-     * @return The username value.
-     */
-    public String getUsername() {
-        return username;
-    }
+  /** The username value. */
+  private String username = null;
 
-    /**
-     * Username value setter.
-     * @param username The new username value.
-     */
-    public void setUsername(final String username) {
-        this.username = username;
-    }
+  /** The password value. */
+  private String password = null;
 
-    /**
-     * Password value getter.
-     * @return The password value.
-     */
-    public String getPassword() {
-        return password;
-    }
+  /** The host value. */
+  private String host = null;
 
-    /**
-     * Password value setter.
-     * @param password The new password value.
-     */
-    public void setPassword(final String password) {
-        this.password = password;
-    }
+  /** The port value. */
+  private Integer port = null;
 
-    /**
-     * Host value getter.
-     * @return The host value.
-     */
-    public String getHost() {
-        return host;
-    }
+  /** The realm value. */
+  private String realm = null;
 
-    /**
-     * Host value setter.
-     * @param host The new Host value.
-     */
-    public void setHost(final String host) {
-        this.host = host;
-    }
-    
-    /**
-     * Port value getter.
-     * @return The port value.
-     */
-    public Integer getPort() {
-        return port;
-    }
+  /** Is this authorization preemptive. */
+  private boolean isPreemptive = true;
 
-    /**
-     * Port value setter.
-     * @param port The new Port value.
-     */
-    public void setPort(final Integer port) {
-        this.port = port;
-    }
+  /**
+   * Constructor setting if the authorization is a Basic typed one. Default Constructor.
+   *
+   * @param basic States if it is a Basic authorization.
+   */
+  public BasicDigestAuthorization(final boolean basic) {
+    this.basic = basic;
+  }
 
-    /**
-     * Realm value getter.
-     * @return The realm value.
-     */
-    public String getRealm() {
-        return realm;
-    }
+  /**
+   * Username value getter.
+   *
+   * @return The username value.
+   */
+  public String getUsername() {
+    return username;
+  }
 
-    /**
-     * Realm value setter.
-     * @param realm The new realm value.
-     */
-    public void setRealm(final String realm) {
-        this.realm = realm;
-    }
+  /**
+   * Username value setter.
+   *
+   * @param username The new username value.
+   */
+  public void setUsername(final String username) {
+    this.username = username;
+  }
 
-    /**
-     * Preemptive value getter.
-     * @return The preemptive value.
-     */
-    public boolean isPreemptive() {
-        return isPreemptive;
-    }
+  /**
+   * Password value getter.
+   *
+   * @return The password value.
+   */
+  public String getPassword() {
+    return password;
+  }
 
-    /**
-     * Preemptive value setter.
-     * @param isPreemptive The new preemptive value.
-     */
-    public void setPreemptive(final boolean isPreemptive) {
-        this.isPreemptive = isPreemptive;
-    }
+  /**
+   * Password value setter.
+   *
+   * @param password The new password value.
+   */
+  public void setPassword(final String password) {
+    this.password = password;
+  }
 
-    /**
-     * Basic value getter.
-     * @return The basic value.
-     */
-    public boolean isBasic() {
-        return basic;
-    }
+  /**
+   * Host value getter.
+   *
+   * @return The host value.
+   */
+  public String getHost() {
+    return host;
+  }
 
-    /**
-     * Basic value setter.
-     * @param basic The new basic value.
-     */
-    public void setBasic(final boolean basic) {
-        this.basic = basic;
-    }
-    
+  /**
+   * Host value setter.
+   *
+   * @param host The new Host value.
+   */
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  /**
+   * Port value getter.
+   *
+   * @return The port value.
+   */
+  public Integer getPort() {
+    return port;
+  }
+
+  /**
+   * Port value setter.
+   *
+   * @param port The new Port value.
+   */
+  public void setPort(final Integer port) {
+    this.port = port;
+  }
+
+  /**
+   * Realm value getter.
+   *
+   * @return The realm value.
+   */
+  public String getRealm() {
+    return realm;
+  }
+
+  /**
+   * Realm value setter.
+   *
+   * @param realm The new realm value.
+   */
+  public void setRealm(final String realm) {
+    this.realm = realm;
+  }
+
+  /**
+   * Preemptive value getter.
+   *
+   * @return The preemptive value.
+   */
+  public boolean isPreemptive() {
+    return isPreemptive;
+  }
+
+  /**
+   * Preemptive value setter.
+   *
+   * @param isPreemptive The new preemptive value.
+   */
+  public void setPreemptive(final boolean isPreemptive) {
+    this.isPreemptive = isPreemptive;
+  }
+
+  /**
+   * Basic value getter.
+   *
+   * @return The basic value.
+   */
+  public boolean isBasic() {
+    return basic;
+  }
+
+  /**
+   * Basic value setter.
+   *
+   * @param basic The new basic value.
+   */
+  public void setBasic(final boolean basic) {
+    this.basic = basic;
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/HTTPMethod.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/HTTPMethod.java
@@ -1,23 +1,23 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * The HTTP methods applicable for REST.
- */
+/** The HTTP methods applicable for REST. */
 public enum HTTPMethod {
-    /**
-     * The items.
-     */
-    GET, POST, PUT, DELETE;
-    
-    /**
-     * Get the RESTHTTPMethod based on a value
-     * @param value The value
-     * @return The associated RESTHTTPMethod value
-     */
-    public static HTTPMethod getRESTHTTPMethodFromValue(final String value) {
-        if (value != null) {
-    		return valueOf(value);
-        }
-        return GET;
+  /** The items. */
+  GET,
+  POST,
+  PUT,
+  DELETE;
+
+  /**
+   * Get the RESTHTTPMethod based on a value
+   *
+   * @param value The value
+   * @return The associated RESTHTTPMethod value
+   */
+  public static HTTPMethod getRESTHTTPMethodFromValue(final String value) {
+    if (value != null) {
+      return valueOf(value);
     }
+    return GET;
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/HeaderAuthorization.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/HeaderAuthorization.java
@@ -1,30 +1,26 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * This class reflects the information for a header authorization of a HTTP request.
- */
+/** This class reflects the information for a header authorization of a HTTP request. */
 public class HeaderAuthorization implements Authorization {
-    
-    /**
-     * The token value.
-     */
-    private String value = null;
-    
-    /**
-     * Value getter.
-     * @return The value.
-     */
-    public String getValue() {
-        return value;
-    }
-    
-    /**
-     * The value setter.
-     * @param value The new value.
-     */
-    public void setValue(final String value) {
-        this.value = value;
-    }
-    
-    
+
+  /** The token value. */
+  private String value = null;
+
+  /**
+   * Value getter.
+   *
+   * @return The value.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * The value setter.
+   *
+   * @param value The new value.
+   */
+  public void setValue(final String value) {
+    this.value = value;
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/Proxy.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/Proxy.java
@@ -1,131 +1,119 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * This class reflects the Proxy settings of a HTTP request.
- */
+/** This class reflects the Proxy settings of a HTTP request. */
 public class Proxy {
 
-    /**
-     * The protocol value.
-     */
-    private ProxyProtocol protocol = ProxyProtocol.HTTP;
+  /** The protocol value. */
+  private ProxyProtocol protocol = ProxyProtocol.HTTP;
 
-    /**
-     * The host value.
-     */
-    private String host = null;
+  /** The host value. */
+  private String host = null;
 
-    /**
-     * The host value.
-     */
-    private Integer port = null;
+  /** The host value. */
+  private Integer port = null;
 
-    /**
-     * The username value.
-     */
-    private String username = null;
+  /** The username value. */
+  private String username = null;
 
-    /**
-     * The password value.
-     */
-    private String password = null;
+  /** The password value. */
+  private String password = null;
 
-    /**
-     * Protocol value getter.
-     * 
-     * @return The protocol value.
-     */
-    public ProxyProtocol getProtocol() {
-        return protocol;
-    }
+  /**
+   * Protocol value getter.
+   *
+   * @return The protocol value.
+   */
+  public ProxyProtocol getProtocol() {
+    return protocol;
+  }
 
-    /**
-     * Protocol value setter.
-     * 
-     * @param protocol The new protocol value.
-     */
-    public void setProtocol(ProxyProtocol protocol) {
-        this.protocol = protocol;
-    }
+  /**
+   * Protocol value setter.
+   *
+   * @param protocol The new protocol value.
+   */
+  public void setProtocol(ProxyProtocol protocol) {
+    this.protocol = protocol;
+  }
 
-    /**
-     * Host value getter.
-     * 
-     * @return The host value.
-     */
-    public String getHost() {
-        return host;
-    }
+  /**
+   * Host value getter.
+   *
+   * @return The host value.
+   */
+  public String getHost() {
+    return host;
+  }
 
-    /**
-     * Host value setter.
-     * 
-     * @param host The new host value.
-     */
-    public void setHost(String host) {
-        this.host = host;
-    }
+  /**
+   * Host value setter.
+   *
+   * @param host The new host value.
+   */
+  public void setHost(String host) {
+    this.host = host;
+  }
 
-    /**
-     * Port value getter.
-     * 
-     * @return The port value.
-     */
-    public Integer getPort() {
-        return port;
-    }
+  /**
+   * Port value getter.
+   *
+   * @return The port value.
+   */
+  public Integer getPort() {
+    return port;
+  }
 
-    /**
-     * Port value setter.
-     * 
-     * @param port The new port value.
-     */
-    public void setPort(Integer port) {
-        this.port = port;
-    }
+  /**
+   * Port value setter.
+   *
+   * @param port The new port value.
+   */
+  public void setPort(Integer port) {
+    this.port = port;
+  }
 
-    /**
-     * Username value getter.
-     * 
-     * @return The username value.
-     */
-    public String getUsername() {
-        return username;
-    }
+  /**
+   * Username value getter.
+   *
+   * @return The username value.
+   */
+  public String getUsername() {
+    return username;
+  }
 
-    /**
-     * Username value setter.
-     * 
-     * @param username The new username value.
-     */
-    public void setUsername(final String username) {
-        this.username = username;
-    }
+  /**
+   * Username value setter.
+   *
+   * @param username The new username value.
+   */
+  public void setUsername(final String username) {
+    this.username = username;
+  }
 
-    /**
-     * Password value getter.
-     * 
-     * @return The password value.
-     */
-    public String getPassword() {
-        return password;
-    }
+  /**
+   * Password value getter.
+   *
+   * @return The password value.
+   */
+  public String getPassword() {
+    return password;
+  }
 
-    /**
-     * Password value setter.
-     * 
-     * @param password The new password value.
-     */
-    public void setPassword(final String password) {
-        this.password = password;
-    }
+  /**
+   * Password value setter.
+   *
+   * @param password The new password value.
+   */
+  public void setPassword(final String password) {
+    this.password = password;
+  }
 
-    /**
-     * Check if it has credentials.
-     * 
-     * @return if it has credentials.
-     */
-    public boolean hasCredentials() {
-        return this.username != null && !this.username.isEmpty();
-    }
+  /**
+   * Check if it has credentials.
+   *
+   * @return if it has credentials.
+   */
+  public boolean hasCredentials() {
+    return this.username != null && !this.username.isEmpty();
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/ProxyProtocol.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/ProxyProtocol.java
@@ -1,11 +1,9 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * The Proxy protocols applicable for REST.
- */
+/** The Proxy protocols applicable for REST. */
 public enum ProxyProtocol {
-    /**
-     * The items;
-     */
-    SOCKS, HTTP, HTTPS;
+  /** The items; */
+  SOCKS,
+  HTTP,
+  HTTPS;
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/Request.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/Request.java
@@ -1,253 +1,247 @@
 package org.bonitasoft.connectors.rest.model;
 
+import java.io.Serializable;
 import java.net.HttpCookie;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.http.Header;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHeader;
 
-
-/**
- * This class reflects the information for a REST request.
- */
+/** This class reflects the information for a REST request. */
 public class Request {
-    
-    /**
-     * The URL.
-     */
-    private URL url;
-    
-    /**
-     * The REST HTTP Method.
-     */
-    private HTTPMethod restMethod;
-    
-    /**
-     * The authorization.
-     */
-    private Authorization authorization;
-    
-    /**
-     * The headers.
-     */
-    private final List<Header> headers = new ArrayList<>();
-    
-    /**
-     * The cookies.
-     */
-    private final List<HttpCookie> cookies = new ArrayList<>();
-    
-    /**
-     * The ssl information.
-     */
-    private SSL ssl;
-    
-    /**
-     * The Proxy information.
-     */
-    private Proxy proxy;
-    
-    /**
-     * Is the request has to follow the redirections.
-     */
-    private boolean redirect;
-    
-    /**
-     * Is the response body has to be digested.
-     */
-    private boolean ignore = false;
-    
-    /**
-     * The body string.
-     */
-    private String body = "";
 
-    private ContentType contentType;
+  /** The URL. */
+  private URL url;
 
-    /**
-     * URL value getter.
-     * @return The URL value.
-     */
-    public URL getUrl() {
-        return url;
-    }
-    
-    /**
-     * The URL value setter.
-     * @param url URL value.
-     */
-    public void setUrl(final URL url) {
-        this.url = url;
-    }
-    
-    /**
-     * RESTHTTPMethod value getter.
-     * @return The RESTHTTPMethod value.
-     */
-    public HTTPMethod getRestMethod() {
-        return restMethod;
-    }
-    
-    /**
-     * RESTHTTPMethod value setter.
-     * @param restMethod The RESTHTTPMethod new value.
-     */
-    public void setRestMethod(final HTTPMethod restMethod) {
-        this.restMethod = restMethod;
-    }
-    
-    /**
-     * Authorization value getter.
-     * @return The authorization value.
-     */
-    public Authorization getAuthorization() {
-        return authorization;
-    }
-    
-    /**
-     * Authorization value setter.
-     * @param authorization The authorization new value.
-     */
-    public void setAuthorization(final Authorization authorization) {
-        this.authorization = authorization;
-    }
-    
-    /**
-     * SSL value getter.
-     * @return The SSL value.
-     */
-    public SSL getSsl() {
-        return ssl;
-    }
-    
-    /**
-     * SSL value setter.
-     * @param ssl The SSL new value.
-     */
-    public void setSsl(final SSL ssl) {
-        this.ssl = ssl;
-    }
-    
-    /**
-     * Proxy value getter.
-     * @return The Proxy value.
-     */
-    public Proxy getProxy() {
-        return proxy;
-    }
-    
-    /**
-     * Proxy value setter.
-     * @param proxy The Proxy new value.
-     */
-    public void setProxy(final Proxy proxy) {
-        this.proxy = proxy;
-    }
-    
-    /**
-     * Redirect value getter.
-     * @return The redirect value.
-     */
-    public boolean isRedirect() {
-        return redirect;
-    }
-    
-    /**
-     * Redirect value setter.
-     * @param redirect The redirect new value.
-     */
-    public void setRedirect(final boolean redirect) {
-        this.redirect = redirect;
-    }
-    
-    /**
-     * Ignore value getter.
-     * @return The ignore value.
-     */
-    public boolean isIgnore() {
-        return ignore;
-    }
-    
-    /**
-     * Ignore value setter.
-     * @param ignore The ignore new value.
-     */
-    public void setIgnore(final boolean ignore) {
-        this.ignore = ignore;
-    }
-    
-    /**
-     * Headers value getter.
-     * @return The headers value.
-     */
-    public List<Header> getHeaders() {
-        return headers;
-    }
-    
-    /**
-     * Cookies value getter.
-     * @return The cookies value.
-     */
-    public List<HttpCookie> getCookies() {
-        return cookies;
-    }
-    
-    /**
-     * Add a header couple in the headers.
-     * @param key The key of the new header.
-     * @param value The lonely value of the new header.
-     * @return True if the header has been added or false otherwise.
-     */
-    public boolean addHeader(final String key, final String value) {
-        return headers.add(new BasicHeader(key,value));
-    }
-    
-    /**
-     * Add a cookie couple in the cookies.
-     * @param key The key of the new cookie.
-     * @param value The lonely value of the new cookie.
-     * @return True if the cookie has been added or false otherwise.
-     */
-    public boolean addCookie(final String key, final String value) {
-        return cookies.add(new HttpCookie(key,  value));
-    }
+  /** The REST HTTP Method. */
+  private HTTPMethod restMethod;
 
-    
-    /**
-     * Body value getter.
-     * @return The body value.
-     */
-    public String getBody() {
-        return body;
-    }
+  /** The authorization. */
+  private Authorization authorization;
 
-    /**
-     * Body value setter.
-     * @param body The body new value.
-     */
-    public void setBody(final String body) {
-        this.body = body;
-    }
-    
+  /** The headers. */
+  private final List<Header> headers = new ArrayList<>();
 
-    public void setContentType(final ContentType contentType) {
-        this.contentType = contentType;
-    }
+  /** The cookies. */
+  private final List<HttpCookie> cookies = new ArrayList<>();
 
+  /** The ssl information. */
+  private SSL ssl;
 
-    public ContentType getContentType() {
-        return contentType;
-    }
-    
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return String.format("[%s] %s", restMethod, url);
-    }
+  /** The Proxy information. */
+  private Proxy proxy;
+
+  /** Is the request has to follow the redirections. */
+  private boolean redirect;
+
+  /** Is the response body has to be digested. */
+  private boolean ignore = false;
+
+  /** The body string. */
+  private Serializable body = "";
+
+  private ContentType contentType;
+
+  /**
+   * URL value getter.
+   *
+   * @return The URL value.
+   */
+  public URL getUrl() {
+    return url;
+  }
+
+  /**
+   * The URL value setter.
+   *
+   * @param url URL value.
+   */
+  public void setUrl(final URL url) {
+    this.url = url;
+  }
+
+  /**
+   * RESTHTTPMethod value getter.
+   *
+   * @return The RESTHTTPMethod value.
+   */
+  public HTTPMethod getRestMethod() {
+    return restMethod;
+  }
+
+  /**
+   * RESTHTTPMethod value setter.
+   *
+   * @param restMethod The RESTHTTPMethod new value.
+   */
+  public void setRestMethod(final HTTPMethod restMethod) {
+    this.restMethod = restMethod;
+  }
+
+  /**
+   * Authorization value getter.
+   *
+   * @return The authorization value.
+   */
+  public Authorization getAuthorization() {
+    return authorization;
+  }
+
+  /**
+   * Authorization value setter.
+   *
+   * @param authorization The authorization new value.
+   */
+  public void setAuthorization(final Authorization authorization) {
+    this.authorization = authorization;
+  }
+
+  /**
+   * SSL value getter.
+   *
+   * @return The SSL value.
+   */
+  public SSL getSsl() {
+    return ssl;
+  }
+
+  /**
+   * SSL value setter.
+   *
+   * @param ssl The SSL new value.
+   */
+  public void setSsl(final SSL ssl) {
+    this.ssl = ssl;
+  }
+
+  /**
+   * Proxy value getter.
+   *
+   * @return The Proxy value.
+   */
+  public Proxy getProxy() {
+    return proxy;
+  }
+
+  /**
+   * Proxy value setter.
+   *
+   * @param proxy The Proxy new value.
+   */
+  public void setProxy(final Proxy proxy) {
+    this.proxy = proxy;
+  }
+
+  /**
+   * Redirect value getter.
+   *
+   * @return The redirect value.
+   */
+  public boolean isRedirect() {
+    return redirect;
+  }
+
+  /**
+   * Redirect value setter.
+   *
+   * @param redirect The redirect new value.
+   */
+  public void setRedirect(final boolean redirect) {
+    this.redirect = redirect;
+  }
+
+  /**
+   * Ignore value getter.
+   *
+   * @return The ignore value.
+   */
+  public boolean isIgnore() {
+    return ignore;
+  }
+
+  /**
+   * Ignore value setter.
+   *
+   * @param ignore The ignore new value.
+   */
+  public void setIgnore(final boolean ignore) {
+    this.ignore = ignore;
+  }
+
+  /**
+   * Headers value getter.
+   *
+   * @return The headers value.
+   */
+  public List<Header> getHeaders() {
+    return headers;
+  }
+
+  /**
+   * Cookies value getter.
+   *
+   * @return The cookies value.
+   */
+  public List<HttpCookie> getCookies() {
+    return cookies;
+  }
+
+  /**
+   * Add a header couple in the headers.
+   *
+   * @param key The key of the new header.
+   * @param value The lonely value of the new header.
+   * @return True if the header has been added or false otherwise.
+   */
+  public boolean addHeader(final String key, final String value) {
+    return headers.add(new BasicHeader(key, value));
+  }
+
+  /**
+   * Add a cookie couple in the cookies.
+   *
+   * @param key The key of the new cookie.
+   * @param value The lonely value of the new cookie.
+   * @return True if the cookie has been added or false otherwise.
+   */
+  public boolean addCookie(final String key, final String value) {
+    return cookies.add(new HttpCookie(key, value));
+  }
+
+  /**
+   * Body value getter.
+   *
+   * @return The body value.
+   */
+  public Serializable getBody() {
+    return body;
+  }
+
+  /**
+   * Body value setter.
+   *
+   * @param body The body new value.
+   */
+  public void setBody(final Serializable body) {
+    this.body = body;
+  }
+
+  public void setContentType(final ContentType contentType) {
+    this.contentType = contentType;
+  }
+
+  public ContentType getContentType() {
+    return contentType;
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return String.format("[%s] %s", restMethod, url);
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/ResultKeyValueMap.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/ResultKeyValueMap.java
@@ -1,77 +1,69 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest.model;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * The key value object of the result of a REST Connector
- */
+/** The key value object of the result of a REST Connector */
 public class ResultKeyValueMap implements Serializable {
 
-    /**
-     * The serial version
-     */
-    private static final long serialVersionUID = 1L;
-    
-    /**
-     * The key of the element
-     */
-    private String key = null;
-    
-    /**
-     * The value of the element which is a list of values
-     */
-    private List<String> value = new ArrayList<String>();
+  /** The serial version */
+  private static final long serialVersionUID = 1L;
 
-    /**
-     * Get the key
-     * @return the key
-     */
-    public String getKey() {
-        return this.key;
-    }
+  /** The key of the element */
+  private String key = null;
 
-    /**
-     * Set the key
-     * @param newKey the key
-     */
-    public void setKey(final String newKey) {
-        this.key = newKey;
-    }
+  /** The value of the element which is a list of values */
+  private List<String> value = new ArrayList<String>();
 
-    /**
-     * Get the value
-     * @return the value
-     */
-    public List<String> getValue() {
-        return this.value;
-    }
+  /**
+   * Get the key
+   *
+   * @return the key
+   */
+  public String getKey() {
+    return this.key;
+  }
 
-    /**
-     * Set the value
-     * @param newValue the value
-     */
-    public void setValue(final List<String> newValue) {
-        this.value = newValue;
-    }
+  /**
+   * Set the key
+   *
+   * @param newKey the key
+   */
+  public void setKey(final String newKey) {
+    this.key = newKey;
+  }
 
-    @Override
-    public String toString() {
-        return "RESTResultKeyValueMap  [key: " + getKey() + "]";
-    }
+  /**
+   * Get the value
+   *
+   * @return the value
+   */
+  public List<String> getValue() {
+    return this.value;
+  }
+
+  /**
+   * Set the value
+   *
+   * @param newValue the value
+   */
+  public void setValue(final List<String> newValue) {
+    this.value = newValue;
+  }
+
+  @Override
+  public String toString() {
+    return "RESTResultKeyValueMap  [key: " + getKey() + "]";
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/SSL.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/SSL.java
@@ -1,101 +1,99 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * This class reflects the information for SSL.
- */
+/** This class reflects the information for SSL. */
 public class SSL {
-    
-    /**
-     * The truststore.
-     */
-    private Store trustStore = null;
 
-    /**
-     * The key store.
-     */
-    private Store keyStore = null;
+  /** The truststore. */
+  private Store trustStore = null;
 
-    /**
-     * The SSL verifier.
-     */
-    private SSLVerifier sslVerifier = SSLVerifier.STRICT;
+  /** The key store. */
+  private Store keyStore = null;
 
-    private TrustCertificateStrategy trustCertificateStrategy = TrustCertificateStrategy.DEFAULT;
+  /** The SSL verifier. */
+  private SSLVerifier sslVerifier = SSLVerifier.STRICT;
 
-    /**
-     * Is TLS has to be used.
-     */
-    private boolean useTLS = false;
+  private TrustCertificateStrategy trustCertificateStrategy = TrustCertificateStrategy.DEFAULT;
 
-    /**
-     * Trust store value getter.
-     * @return The truststore value.
-     */
-    public Store getTrustStore() {
-        return trustStore;
-    }
+  /** Is TLS has to be used. */
+  private boolean useTLS = false;
 
-    /**
-     * Truststore value setter.
-     * @param trustStore The truststore new value.
-     */
-    public void setTrustStore(final Store trustStore) {
-        this.trustStore = trustStore;
-    }
-    
-    /**
-     * Key store value getter.
-     * @return The key store value.
-     */
-    public Store getKeyStore() {
-        return keyStore;
-    }
+  /**
+   * Trust store value getter.
+   *
+   * @return The truststore value.
+   */
+  public Store getTrustStore() {
+    return trustStore;
+  }
 
-    /**
-     * Keystore value setter.
-     * @param keyStore The keystore new value.
-     */
-    public void setKeyStore(final Store keyStore) {
-        this.keyStore = keyStore;
-    }
+  /**
+   * Truststore value setter.
+   *
+   * @param trustStore The truststore new value.
+   */
+  public void setTrustStore(final Store trustStore) {
+    this.trustStore = trustStore;
+  }
 
-    /**
-     * SSL verifier value getter.
-     * @return The SSL verifier value.
-     */
-    public SSLVerifier getSslVerifier() {
-        return sslVerifier;
-    }
+  /**
+   * Key store value getter.
+   *
+   * @return The key store value.
+   */
+  public Store getKeyStore() {
+    return keyStore;
+  }
 
-    /**
-     * SSL verifier value setter.
-     * @param sslVerifier The SSL verifier new value.
-     */
-    public void setSslVerifier(final SSLVerifier sslVerifier) {
-        this.sslVerifier = sslVerifier;
-    }
+  /**
+   * Keystore value setter.
+   *
+   * @param keyStore The keystore new value.
+   */
+  public void setKeyStore(final Store keyStore) {
+    this.keyStore = keyStore;
+  }
 
-    public TrustCertificateStrategy getTrustCertificateStrategy() {
-        return trustCertificateStrategy;
-    }
+  /**
+   * SSL verifier value getter.
+   *
+   * @return The SSL verifier value.
+   */
+  public SSLVerifier getSslVerifier() {
+    return sslVerifier;
+  }
 
-    public void setTrustCertificateStrategy(final TrustCertificateStrategy trustCertificateStrategy) {
-        this.trustCertificateStrategy = trustCertificateStrategy;
-    }
-    
-    /**
-     * Use TLS value getter.
-     * @return The Use TLS value.
-     */
-    public boolean isUseTLS() {
-        return useTLS;
-    }
+  /**
+   * SSL verifier value setter.
+   *
+   * @param sslVerifier The SSL verifier new value.
+   */
+  public void setSslVerifier(final SSLVerifier sslVerifier) {
+    this.sslVerifier = sslVerifier;
+  }
 
-    /**
-     * Use TLS setter.
-     * @param useTLS The Use TLS new value.
-     */
-    public void setUseTLS(final boolean useTLS) {
-        this.useTLS = useTLS;
-    }
+  public TrustCertificateStrategy getTrustCertificateStrategy() {
+    return trustCertificateStrategy;
+  }
+
+  public void setTrustCertificateStrategy(final TrustCertificateStrategy trustCertificateStrategy) {
+    this.trustCertificateStrategy = trustCertificateStrategy;
+  }
+
+  /**
+   * Use TLS value getter.
+   *
+   * @return The Use TLS value.
+   */
+  public boolean isUseTLS() {
+    return useTLS;
+  }
+
+  /**
+   * Use TLS setter.
+   *
+   * @param useTLS The Use TLS new value.
+   */
+  public void setUseTLS(final boolean useTLS) {
+    this.useTLS = useTLS;
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/SSLVerifier.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/SSLVerifier.java
@@ -1,53 +1,51 @@
 package org.bonitasoft.connectors.rest.model;
 
-/**
- * The SSL verifiers applicable for REST.
- */
+/** The SSL verifiers applicable for REST. */
 public enum SSLVerifier {
-    /**
-     * The items;
-     */
-    STRICT("Strict"), BROWSER("BROWSER COMPATIBLE"), ALLOW("ALLOW ALL");
-    
-    /**
-     * The value of a item.
-     */
-    private String value = null;
-    
-    /**
-     * Constructor to set the value of the created item.
-     * Default Constructor.
-     * @param value The value of the item.
-     */
-    SSLVerifier(final String value) {
-        this.value = value;
-    }
-    
-    /**
-     * Value getter.
-     * @return The value.
-     */
-    public String getValue() {
-        return value;
-    }
-    
-    /**
-     * Get the SSLVerifier value based on a given value, by default STRICT is returned.
-     * @param value The value.
-     * @return The associated SSLVerifier value.
-     */
-    public static SSLVerifier getSSLVerifierFromValue(final String value) {
-        if (value != null) {
-            if (STRICT.value.equals(value)) {
-                return SSLVerifier.STRICT;
-            }
-            if (BROWSER.value.equals(value)) {
-                return SSLVerifier.BROWSER;
-            }
-            if (ALLOW.value.equals(value)) {
-                return SSLVerifier.ALLOW;
-            }
-        }
+  /** The items; */
+  STRICT("Strict"),
+  BROWSER("BROWSER COMPATIBLE"),
+  ALLOW("ALLOW ALL");
+
+  /** The value of a item. */
+  private String value = null;
+
+  /**
+   * Constructor to set the value of the created item. Default Constructor.
+   *
+   * @param value The value of the item.
+   */
+  SSLVerifier(final String value) {
+    this.value = value;
+  }
+
+  /**
+   * Value getter.
+   *
+   * @return The value.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Get the SSLVerifier value based on a given value, by default STRICT is returned.
+   *
+   * @param value The value.
+   * @return The associated SSLVerifier value.
+   */
+  public static SSLVerifier getSSLVerifierFromValue(final String value) {
+    if (value != null) {
+      if (STRICT.value.equals(value)) {
         return SSLVerifier.STRICT;
+      }
+      if (BROWSER.value.equals(value)) {
+        return SSLVerifier.BROWSER;
+      }
+      if (ALLOW.value.equals(value)) {
+        return SSLVerifier.ALLOW;
+      }
     }
+    return SSLVerifier.STRICT;
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/Store.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/Store.java
@@ -4,71 +4,67 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 
-/**
- * A basic key store to be used in a HTTP request.
- */
+/** A basic key store to be used in a HTTP request. */
 public class Store {
-    
-    /**
-     * The type of the key store.
-     */
-    private static String keyStoreType = "JKS";
-    
-    /**
-     * The file.
-     */
-    private File file = null;
-    
-    /**
-     * The password.
-     */
-    private String password = null;
 
-    /**
-     * Generate the key store based on the options.
-     * @return The generated key store.
-     * @throws Exception In case of any exception
-     */
-    public KeyStore generateKeyStore() throws Exception {
-        KeyStore store  = KeyStore.getInstance(keyStoreType);
-        if (file != null) {
-            try (FileInputStream instream = new FileInputStream(file)) {
-                store.load(instream, password.toCharArray());
-            }
-        }
-        return store;
-    }
+  /** The type of the key store. */
+  private static String keyStoreType = "JKS";
 
-    /**
-     * File value getter.
-     * @return The file value.
-     */
-    public File getFile() {
-        return file;
-    }
-    
-    /**
-     * File value setter.
-     * @param file The new file value.
-     */
-    public void setFile(final File file) {
-        this.file = file;
-    }
+  /** The file. */
+  private File file = null;
 
-    /**
-     * Password value getter.
-     * @return The password value.
-     */
-    public String getPassword() {
-        return password;
-    }
+  /** The password. */
+  private String password = null;
 
-    /**
-     * Password value setter.
-     * @param password The password file value.
-     */
-    public void setPassword(final String password) {
-        this.password = password;
+  /**
+   * Generate the key store based on the options.
+   *
+   * @return The generated key store.
+   * @throws Exception In case of any exception
+   */
+  public KeyStore generateKeyStore() throws Exception {
+    KeyStore store = KeyStore.getInstance(keyStoreType);
+    if (file != null) {
+      try (FileInputStream instream = new FileInputStream(file)) {
+        store.load(instream, password.toCharArray());
+      }
     }
-    
+    return store;
+  }
+
+  /**
+   * File value getter.
+   *
+   * @return The file value.
+   */
+  public File getFile() {
+    return file;
+  }
+
+  /**
+   * File value setter.
+   *
+   * @param file The new file value.
+   */
+  public void setFile(final File file) {
+    this.file = file;
+  }
+
+  /**
+   * Password value getter.
+   *
+   * @return The password value.
+   */
+  public String getPassword() {
+    return password;
+  }
+
+  /**
+   * Password value setter.
+   *
+   * @param password The password file value.
+   */
+  public void setPassword(final String password) {
+    this.password = password;
+  }
 }

--- a/src/main/java/org/bonitasoft/connectors/rest/model/TrustCertificateStrategy.java
+++ b/src/main/java/org/bonitasoft/connectors/rest/model/TrustCertificateStrategy.java
@@ -1,7 +1,7 @@
 package org.bonitasoft.connectors.rest.model;
 
 public enum TrustCertificateStrategy {
-
-	DEFAULT, TRUST_SELF_SIGNED, TRUST_ALL
-	
+  DEFAULT,
+  TRUST_SELF_SIGNED,
+  TRUST_ALL
 }

--- a/src/main/resources-filtered/rest-post.def
+++ b/src/main/resources-filtered/rest-post.def
@@ -11,7 +11,7 @@
   <input name="charset" type="java.lang.String" mandatory="true" defaultValue="UTF-8"/>
   <input name="urlCookies" type="java.util.List" mandatory="false"/>
   <input name="urlHeaders" type="java.util.List"/>
-  <input name="body" type="java.lang.String" mandatory="false"/>
+  <input name="body" type="java.io.Serializable" mandatory="false"/>
   <input name="do_not_follow_redirect" type="java.lang.Boolean" mandatory="false"/>
   <input name="ignore_body" type="java.lang.Boolean" mandatory="false"/>
   <input name="TLS" type="java.lang.Boolean" mandatory="false" defaultValue="true"/>
@@ -48,6 +48,7 @@
     <widget xsi:type="definition:Text" id="urlWidget" inputName="url"/>
     <widget xsi:type="definition:Select" id="contentTypeWidget" inputName="contentType">
 		<items>application/json</items>
+		<items>application/octet-stream</items>
 		<items>application/xml</items>
 		<items>application/x-www-form-urlencoded</items>
 		<items>text/html</items>

--- a/src/main/resources-filtered/rest-put.def
+++ b/src/main/resources-filtered/rest-put.def
@@ -11,7 +11,7 @@
   <input name="charset" type="java.lang.String" mandatory="true" defaultValue="UTF-8"/>
   <input name="urlCookies" type="java.util.List" mandatory="false"/>
   <input name="urlHeaders" type="java.util.List"/>
-  <input name="body" type="java.lang.String" mandatory="false"/>
+  <input name="body" type="java.io.Serializable" mandatory="false"/>
   <input name="do_not_follow_redirect" type="java.lang.Boolean" mandatory="false"/>
   <input name="ignore_body" type="java.lang.Boolean" mandatory="false"/>
   <input name="TLS" type="java.lang.Boolean" mandatory="false" defaultValue="true"/>
@@ -48,6 +48,7 @@
     <widget xsi:type="definition:Text" id="urlWidget" inputName="url"/>
     <widget xsi:type="definition:Select" id="contentTypeWidget" inputName="contentType">
 		<items>application/json</items>
+		<items>application/octet-stream</items>
 		<items>application/xml</items>
 		<items>application/x-www-form-urlencoded</items>
 		<items>text/html</items>

--- a/src/test/java/org/bonitasoft/connectors/rest/AcceptanceTestBase.java
+++ b/src/test/java/org/bonitasoft/connectors/rest/AcceptanceTestBase.java
@@ -1,19 +1,20 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
+import com.github.tomakehurst.wiremock.Log4jConfiguration;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Log4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.bonitasoft.engine.api.APIAccessor;
 import org.bonitasoft.engine.api.ProcessAPI;
 import org.bonitasoft.engine.connector.EngineExecutionContext;
@@ -22,109 +23,91 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
 
-import com.github.tomakehurst.wiremock.Log4jConfiguration;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.Log4jNotifier;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-
 /**
- * This class is used to handle WireMock Jetty server and BonitaSoft mock for the REST Connector UTs.
+ * This class is used to handle WireMock Jetty server and BonitaSoft mock for the REST Connector
+ * UTs.
  */
 public class AcceptanceTestBase {
 
-    /**
-     * The engine execution context of the BonitaSoft mock
-     */
-    private EngineExecutionContext engineExecutionContext;
+  /** The engine execution context of the BonitaSoft mock */
+  private EngineExecutionContext engineExecutionContext;
 
-    /**
-     * The apiAccessor BonitaSoft mock
-     */
-    private APIAccessor apiAccessor;
+  /** The apiAccessor BonitaSoft mock */
+  private APIAccessor apiAccessor;
 
-    /**
-     * The process API BonitaSoft mock
-     */
-    private ProcessAPI processAPI;
+  /** The process API BonitaSoft mock */
+  private ProcessAPI processAPI;
 
-    /**
-     * The WireMock server (mock of the REST services)
-     */
-    protected static WireMockServer wireMockServer;
+  /** The WireMock server (mock of the REST services) */
+  protected static WireMockServer wireMockServer;
 
-    /**
-     * The URL of the WireMock server
-     */
-    protected static final String LOCALHOST = "LOCALHOST";
+  /** The URL of the WireMock server */
+  protected static final String LOCALHOST = "LOCALHOST";
 
-    /**
-     * The setup of the WireMock server
-     */
-    @BeforeClass
-    public static void setupServer() {
-        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0).notifier(new Log4jNotifier()));
-        wireMockServer.start();
-    }
+  /** The setup of the WireMock server */
+  @BeforeClass
+  public static void setupServer() {
+    wireMockServer =
+        new WireMockServer(
+            WireMockConfiguration.wireMockConfig().port(0).notifier(new Log4jNotifier()));
+    wireMockServer.start();
+  }
 
-    /**
-     * The setdown of the WireMock server
-     */
-    @AfterClass
-    public static void serverShutdown() {
-        wireMockServer.stop();
-    }
+  /** The setdown of the WireMock server */
+  @AfterClass
+  public static void serverShutdown() {
+    wireMockServer.stop();
+  }
 
-    /**
-     * Initialization of the whole test environment
-     *
-     * @throws InterruptedException exception
-     */
-    @Before
-    public void init() {
-        setEngineExecutionContext(Mockito.mock(EngineExecutionContext.class));
-        apiAccessor = Mockito.mock(APIAccessor.class);
-        processAPI = Mockito.mock(ProcessAPI.class);
-        Mockito.when(apiAccessor.getProcessAPI()).thenReturn(processAPI);
-        WireMock.configureFor(LOCALHOST, wireMockServer.port());
-        Log4jConfiguration.configureLogging(true);
-        WireMock.reset();
-    }
+  /**
+   * Initialization of the whole test environment
+   *
+   * @throws InterruptedException exception
+   */
+  @Before
+  public void init() {
+    setEngineExecutionContext(Mockito.mock(EngineExecutionContext.class));
+    apiAccessor = Mockito.mock(APIAccessor.class);
+    processAPI = Mockito.mock(ProcessAPI.class);
+    Mockito.when(apiAccessor.getProcessAPI()).thenReturn(processAPI);
+    WireMock.configureFor(LOCALHOST, wireMockServer.port());
+    Log4jConfiguration.configureLogging(true);
+    WireMock.reset();
+  }
 
-    /**
-     * Get the engine execution context
-     * 
-     * @return the engine execution context
-     */
-    public EngineExecutionContext getEngineExecutionContext() {
-        return engineExecutionContext;
-    }
+  /**
+   * Get the engine execution context
+   *
+   * @return the engine execution context
+   */
+  public EngineExecutionContext getEngineExecutionContext() {
+    return engineExecutionContext;
+  }
 
-    /**
-     * Set the engine execution context
-     * 
-     * @param engineExecutionContext the engine execution context
-     */
-    public void setEngineExecutionContext(final EngineExecutionContext engineExecutionContext) {
-        this.engineExecutionContext = engineExecutionContext;
-    }
+  /**
+   * Set the engine execution context
+   *
+   * @param engineExecutionContext the engine execution context
+   */
+  public void setEngineExecutionContext(final EngineExecutionContext engineExecutionContext) {
+    this.engineExecutionContext = engineExecutionContext;
+  }
 
-    /**
-     * Get the API accessor
-     * 
-     * @return the API accessor
-     */
-    public APIAccessor getApiAccessor() {
-        return apiAccessor;
-    }
+  /**
+   * Get the API accessor
+   *
+   * @return the API accessor
+   */
+  public APIAccessor getApiAccessor() {
+    return apiAccessor;
+  }
 
-    /**
-     * Set the API accessor
-     * 
-     * @param apiAccessor the API accessor
-     */
-    public void setApiAccessor(final APIAccessor apiAccessor) {
-        this.apiAccessor = apiAccessor;
-    }
-
+  /**
+   * Set the API accessor
+   *
+   * @param apiAccessor the API accessor
+   */
+  public void setApiAccessor(final APIAccessor apiAccessor) {
+    this.apiAccessor = apiAccessor;
+  }
 }

--- a/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/rest/RESTConnectorTest.java
@@ -1,37 +1,26 @@
 /**
- * Copyright (C) 2014 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This library is free software; you can redistribute it and/or modify it under the terms
- * of the GNU Lesser General Public License as published by the Free Software Foundation
- * version 2.1 of the License.
- * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
- * Floor, Boston, MA 02110-1301, USA.
- **/
-
+ * Copyright (C) 2014 BonitaSoft S.A. BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble This
+ * library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation version 2.1 of the
+ * License. This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU Lesser General Public License for more details. You should have received a
+ * copy of the GNU Lesser General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.bonitasoft.connectors.rest;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.github.tomakehurst.wiremock.client.WireMock.delete;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.put;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.bonitasoft.connectors.rest.AbstractRESTConnectorImpl.BODY_INPUT_PARAMETER;
+import static org.bonitasoft.connectors.rest.AbstractRESTConnectorImpl.METHOD_INPUT_PARAMETER;
 import static org.hamcrest.core.Is.isA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.google.common.collect.Maps;
 import java.io.UnsupportedEncodingException;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
@@ -44,7 +33,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
 import org.bonitasoft.connectors.rest.model.AuthorizationType;
@@ -58,1056 +46,1305 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.github.tomakehurst.wiremock.client.MappingBuilder;
-import com.google.common.collect.Maps;
-
-/**
- * The class for the UTs of the REST Connector
- */
+/** The class for the UTs of the REST Connector */
 public class RESTConnectorTest extends AcceptanceTestBase {
 
-	private static final int NB_OUTPUTS = 5;
-
-	// WireMock
-	/**
-	 * All HTTP static strings used by WireMock to do tests
-	 */
-	private static final String WM_CONTENT_TYPE = "Content-Type";
-	private static final String WM_CHARSET = "charset";
-	private static final String WM_COOKIES = "Cookie";
-	private static final String WM_AUTHORIZATION = "Authorization";
-
-	// METHODS
-	/**
-	 * All the tested method values
-	 */
-	private static final String GET = "GET";
-	private static final String POST = "POST";
-	private static final String PUT = "PUT";
-	private static final String DELETE = "DELETE";
-	private static final String METHOD_ERROR = "FAKE_METHOD";
-
-	// CONTENT_TYPES
-	/**
-	 * All the tested content type values
-	 */
-	private static final String PLAIN_TEXT = "text/plain";
-	private static final String JSON = "application/json";
-	private static final String CONTENT_TYPE_ERROR = "fakecontenttype";
-
-	// CHARSETS
-	/**
-	 * All the tested charset values
-	 */
-	private static final String UTF8 = "UTF-8";
-	private static final String ISO_8859_1 = "ISO-8859-1";
-	private static final String US_ASCII = "US-ASCII";
-	private static final String CHARSET_ERROR = "FAKE-CHARSET";
-
-	// COOKIES
-	/**
-	 * All the tested cookies values
-	 */
-	private static final List<List<String>> ONE_COOKIES = new ArrayList<>();
-	private static final List<List<String>> TWO_COOKIES = new ArrayList<>();
-	private static final List<List<String>> COOKIES_ERROR = new ArrayList<>();
-
-	// HEADERS
-	/**
-	 * All the tested headers values
-	 */
-	private static final List<List<String>> ONE_HEADERS = new ArrayList<>();
-	private static final List<List<String>> TWO_HEADERS = new ArrayList<>();
-	private static final List<List<String>> HEADERS_ERROR = new ArrayList<>();
-
-	// BODYS
-	/**
-	 * All the tested bodies values
-	 */
-	private static final String EMPTY = "";
-	private static final String FULL = "there is something inside";
-
-	// SSL VERIFIERS
-	/**
-	 * All the tested SSL verifier values
-	 */
-	private static final String STRICT = "Strict";
-
-	// AUTHORIZATIONS
-	/**
-	 * All the tested authorization values
-	 */
-	private static final String BASIC_RULE = "Basic";
-	private static final String USERNAME = "username";
-	private static final String PASSWORD = "password";
-	private static final String REALM = "realm";
-	private static final String HOST = "localhost";
-	// private static final String TOKEN = "token";
-
-	// OTHER ERRORS
-	/**
-	 * All the tested errors
-	 */
-	private static final String FAKE_URL = "fakeURL";
-
-	/**
-	 * Used to assert Exceptions
-	 */
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
-	/**
-	 * Initialize the tested values
-	 */
-	@BeforeClass
-	public static final void initValues() {
-		final List<String> cookie1 = new ArrayList<>();
-		cookie1.add("cookie1name");
-		cookie1.add("cookie1value");
-		ONE_COOKIES.add(cookie1);
-
-		final List<String> cookie2 = new ArrayList<>();
-		cookie2.add("cookie2name");
-		cookie2.add("cookie2value");
-		TWO_COOKIES.add(cookie1);
-		TWO_COOKIES.add(cookie2);
-
-		final List<String> cookie3 = new ArrayList<>();
-		cookie3.add("cookie3name");
-		cookie3.add("cookie3value");
-		cookie3.add("cookie3extrat");
-		final List<String> cookie4 = new ArrayList<>();
-		cookie4.add("cookie4nameonly");
-		COOKIES_ERROR.add(cookie1);
-		COOKIES_ERROR.add(cookie2);
-		COOKIES_ERROR.add(cookie3);
-		COOKIES_ERROR.add(cookie4);
-
-		final List<String> header1 = new ArrayList<>();
-		header1.add("header1name");
-		header1.add("header1value");
-		ONE_HEADERS.add(header1);
-
-		final List<String> header2 = new ArrayList<>();
-		header2.add("header2name");
-		header2.add("header2value");
-		TWO_HEADERS.add(header1);
-		TWO_HEADERS.add(header2);
-
-		final List<String> header3 = new ArrayList<>();
-		header3.add("header3name");
-		header3.add("header3value");
-		header3.add("header3extrat");
-		final List<String> header4 = new ArrayList<>();
-		header4.add("header4nameonly");
-		HEADERS_ERROR.add(header1);
-		HEADERS_ERROR.add(header2);
-		HEADERS_ERROR.add(header3);
-		HEADERS_ERROR.add(header4);
-	}
-
-	@After
-	public void resetSystemProperies() throws Exception {
-		System.setProperty(RESTConnector.DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY, "");
-	}
-
-	/**
-	 * Build a request parameters set based on the given arguments
-	 * 
-	 * @param url         URL
-	 * @param port        Port
-	 * @param method      Method
-	 * @param contentType Content type
-	 * @param charset     Charset
-	 * @param cookies     Cookies
-	 * @param headers     Headers
-	 * @param body        Body content
-	 * @param redirect    Is the redirection to be used
-	 * @param ignoreBody  Does the response body is ignored
-	 * @param trust       Trust self certificate
-	 * @param sslVerifier SSL Verifier
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildParametersSet(final String url, final String port, final String method,
-			final String contentType, final String charset, final List<List<String>> cookies,
-			final List<List<String>> headers, final String body, final Boolean redirect, final Boolean ignoreBody,
-			final TrustCertificateStrategy trustCertificateStrategy, final String sslVerifier) {
-		final Map<String, Object> parametersSet = new HashMap<>();
-		if (url == null && port == null) {
-			parametersSet.put(AbstractRESTConnectorImpl.URL_INPUT_PARAMETER,
-					"http://" + LOCALHOST + ":" + wireMockServer.port() + "/");
-		} else if (url != null && port == null) {
-			parametersSet.put(AbstractRESTConnectorImpl.URL_INPUT_PARAMETER,
-					"http://" + url + ":" + wireMockServer.port() + "/");
-		} else if (url == null && port != null) {
-			parametersSet.put(AbstractRESTConnectorImpl.URL_INPUT_PARAMETER, "http://" + LOCALHOST + ":" + port + "/");
-		} else {
-			parametersSet.put(AbstractRESTConnectorImpl.URL_INPUT_PARAMETER, "http://" + url + ":" + port + "/");
-		}
-		parametersSet.put(AbstractRESTConnectorImpl.METHOD_INPUT_PARAMETER, method);
-		parametersSet.put(AbstractRESTConnectorImpl.CONTENTTYPE_INPUT_PARAMETER, contentType);
-		parametersSet.put(AbstractRESTConnectorImpl.CHARSET_INPUT_PARAMETER, charset);
-		parametersSet.put(AbstractRESTConnectorImpl.URLCOOKIES_INPUT_PARAMETER, cookies);
-		parametersSet.put(AbstractRESTConnectorImpl.URLHEADERS_INPUT_PARAMETER, headers);
-		parametersSet.put(AbstractRESTConnectorImpl.BODY_INPUT_PARAMETER, body);
-		parametersSet.put(AbstractRESTConnectorImpl.DO_NOT_FOLLOW_REDIRECT_INPUT_PARAMETER, redirect);
-		parametersSet.put(AbstractRESTConnectorImpl.IGNORE_BODY_INPUT_PARAMETER, ignoreBody);
-		parametersSet.put(AbstractRESTConnectorImpl.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER,
-				trustCertificateStrategy.name());
-		parametersSet.put(AbstractRESTConnectorImpl.HOSTNAME_VERIFIER_INPUT_PARAMETER, sslVerifier);
-		return parametersSet;
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific URL
-	 * 
-	 * @param url URL
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildURLParametersSet(final String url) {
-		return buildParametersSet(url, null, POST, PLAIN_TEXT, UTF8, ONE_COOKIES, ONE_HEADERS, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific port
-	 * 
-	 * @param port Port
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildPortParametersSet(final String port) {
-		return buildParametersSet(null, port, POST, PLAIN_TEXT, UTF8, ONE_COOKIES, ONE_HEADERS, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific Method
-	 * 
-	 * @param method Method
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildMethodParametersSet(final String method) {
-		return buildParametersSet(null, null, method, PLAIN_TEXT, UTF8, ONE_COOKIES, ONE_HEADERS, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific Content Type
-	 * 
-	 * @param contentType Content Type
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildContentTypeParametersSet(final String contentType) {
-		return buildParametersSet(null, null, POST, contentType, UTF8, ONE_COOKIES, ONE_HEADERS, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific Charset
-	 * 
-	 * @param charset Charset
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildCharsetParametersSet(final String charset) {
-		return buildParametersSet(null, null, POST, PLAIN_TEXT, charset, ONE_COOKIES, ONE_HEADERS, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific Cookies
-	 * 
-	 * @param cookies Cookies
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildCookieParametersSet(final List<List<String>> cookies) {
-		return buildParametersSet(null, null, GET, PLAIN_TEXT, UTF8, cookies, ONE_HEADERS, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific headers
-	 * 
-	 * @param headers Headers
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildHeaderParametersSet(final List<List<String>> headers) {
-		return buildParametersSet(null, null, GET, PLAIN_TEXT, UTF8, ONE_COOKIES, headers, EMPTY, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific body content
-	 * 
-	 * @param body Body content
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildBodyParametersSet(final String body) {
-		return buildParametersSet(null, null, POST, PLAIN_TEXT, UTF8, ONE_COOKIES, ONE_HEADERS, body, Boolean.FALSE,
-				Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-	}
-
-	/**
-	 * Build a request parameters set in order to test a specific Basic
-	 * Authorization
-	 * 
-	 * @param username   Username
-	 * @param password   Password
-	 * @param host       Host
-	 * @param realm      Realm
-	 * @param preemptive Preemptive
-	 * @return The set of parameters
-	 */
-	private Map<String, Object> buildBasicAuthorizationParametersSet(final String username, final String password,
-			final String host, final String realm, final Boolean preemptive) {
-		final Map<String, Object> parametersSet = buildParametersSet(null, null, GET, PLAIN_TEXT, UTF8, ONE_COOKIES,
-				ONE_HEADERS, EMPTY, Boolean.FALSE, Boolean.FALSE, TrustCertificateStrategy.DEFAULT, STRICT);
-
-		parametersSet.put(AbstractRESTConnectorImpl.AUTH_TYPE_PARAMETER, AuthorizationType.BASIC.name());
-		parametersSet.put(AbstractRESTConnectorImpl.AUTH_USERNAME_INPUT_PARAMETER, username);
-		parametersSet.put(AbstractRESTConnectorImpl.AUTH_PASSWORD_INPUT_PARAMETER, password);
-		parametersSet.put(AbstractRESTConnectorImpl.AUTH_HOST_INPUT_PARAMETER, host);
-		parametersSet.put(AbstractRESTConnectorImpl.AUTH_REALM_INPUT_PARAMETER, realm);
-		parametersSet.put(AbstractRESTConnectorImpl.AUTH_PREEMPTIVE_INPUT_PARAMETER, preemptive);
-
-		return parametersSet;
-	}
-
-	/**
-	 * Execute a connector call
-	 * 
-	 * @param parameters The parameters of the connector call
-	 * @return The outputs of the connector
-	 * @throws BonitaException exception
-	 */
-	private Map<String, Object> executeConnector(final Map<String, Object> parameters) throws BonitaException {
-		final RESTConnector rest = new RESTConnector();
-		rest.setExecutionContext(getEngineExecutionContext());
-		rest.setAPIAccessor(getApiAccessor());
-		rest.setInputParameters(parameters);
-		rest.validateInputParameters();
-		return rest.execute();
-	}
-
-	/**
-	 * Test the GET method
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void getMethod() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildMethodParametersSet(GET)));
-	}
-
-	/**
-	 * Test the POST method
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void postMethod() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildMethodParametersSet(POST)));
-	}
-
-	/**
-	 * Test the PUT method
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void putMethod() throws BonitaException {
-		stubFor(put(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildMethodParametersSet(PUT)));
-	}
-
-	/**
-	 * Test the DELETE method
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void deleteMethod() throws BonitaException {
-		stubFor(delete(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildMethodParametersSet(DELETE)));
-	}
-
-	/**
-	 * Test the FAKE method
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void fakeMethod() throws BonitaException {
-		thrown.expect(BonitaException.class);
-		thrown.expectMessage(
-				"java.lang.IllegalArgumentException: No enum constant org.bonitasoft.connectors.rest.model.HTTPMethod.FAKE_METHOD");
-
-		checkResultIsPresent(executeConnector(buildMethodParametersSet(METHOD_ERROR)));
-	}
-
-	/**
-	 * Test the plain text content type
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void plainTextContentType() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildContentTypeParametersSet(PLAIN_TEXT)));
-	}
-
-	/**
-	 * Test the json content type
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void should_retrieve_response_as_a_Map_jsonContentType() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("{ \"name\":\"Romain\" }")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Map<String, Object> bodyAsMap = (Map<String, Object>) outputs
-				.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsMap);
-		assertEquals(bodyAsMap.get("name"), "Romain");
-	}
-
-	/**
-	 * Test the json content type with wrong content
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void should_not_raise_exception_on_json_parsing_error() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("{ this is not valid json ! }")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Map<String, Object> bodyAsMap = (Map<String, Object>) outputs
-				.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsMap);
-		assertEquals(bodyAsMap.size(), 0);
-	}
-
-	/**
-	 * Test the json simple string value
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void json_simple_string_value_should_return_string_object() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("\"this is a string\"")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsObject);
-		final String bodyAsString = (String) bodyAsObject;
-		assertEquals(bodyAsString, "this is a string");
-	}
-
-	/**
-	 * Test the json simple numeric value
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void json_simple_numeric_value_should_return_number_object() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(
-						aResponse().withStatus(HttpStatus.SC_OK).withBody("123.45").withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsObject);
-		final Number bodyAsNumber = (Number) bodyAsObject;
-		assertEquals(bodyAsNumber, 123.45);
-	}
-
-	/**
-	 * Test the json simple boolean value
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void json_simple_boolean_value_should_return_boolean_object() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(
-						aResponse().withStatus(HttpStatus.SC_OK).withBody("true").withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsObject);
-		final Boolean bodyAsBoolean = (Boolean) bodyAsObject;
-		assertEquals(bodyAsBoolean, true);
-	}
-
-	/**
-	 * Test the json simple date value
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void json_simple_date_value_should_return_iso8601_date_string() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("\"2012-04-23T18:25:43+02:00\"")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsObject);
-		final Instant bodyAsInstant = OffsetDateTime.parse((String) bodyAsObject).toInstant();
-		assertEquals(bodyAsInstant, OffsetDateTime.of(2012, 4, 23, 18, 25, 43, 0, ZoneOffset.ofHours(2)).toInstant());
-	}
-
-	/**
-	 * Test the json simple null value
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void json_simple_null_value_should_return_null() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(
-						aResponse().withStatus(HttpStatus.SC_OK).withBody("null").withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Object bodyAsObject = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNull(bodyAsObject);
-	}
-
-	@Test
-	public void should_retrieve_response_as_a_List_of_Map__jsonContentType() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("[{ \"name\":\"Romain\" }]")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final Object bodyAsMap = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsMap);
-		assertEquals(((Map<String, Object>) ((List) bodyAsMap).get(0)).get("name"), "Romain");
-	}
-
-	@Test
-	public void should_retrieve_response_as_a_List_of_string() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK).withBody("[\"abc\", \"def\"]")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
-		checkResultIsPresent(outputs);
-		final List<String> bodyAsList = (List<String>) outputs
-				.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
-		assertNotNull(bodyAsList);
-		assertEquals(bodyAsList.get(0), "abc");
-		assertEquals(bodyAsList.get(1), "def");
-	}
-
-	@Test
-	public void should_close_connection_when_delay_is_more_than_socket_timeout() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withFixedDelay(1000).withStatus(HttpStatus.SC_OK).withBody("")
-						.withHeader(WM_CONTENT_TYPE, JSON)));
-
-		thrown.expect(ConnectorException.class);
-		Map<String, Object> parameters = buildContentTypeParametersSet(JSON);
-		parameters.put("socket_timeout_ms", 50);
-		executeConnector(parameters);
-	}
-
-	@Test
-	public void should_have_default_timeout() {
-		assertTrue(new RESTConnector().getSocketTimeoutMs() > 0);
-		assertTrue(new RESTConnector().getConnectionTimeoutMs() > 0);
-	}
-
-	/**
-	 * Test the fake content type
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void fakeContentType() throws BonitaException {
-		stubFor(post(urlEqualTo("/"))
-				.withHeader(WM_CONTENT_TYPE, equalTo(CONTENT_TYPE_ERROR + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildContentTypeParametersSet(CONTENT_TYPE_ERROR)));
-	}
-
-	/**
-	 * Test the UTF8 charset
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void utf8Charset() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildCharsetParametersSet(UTF8)));
-	}
-
-	/**
-	 * Test the ISO-8859-1 charset
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void iso88591CharsetRequest() throws BonitaException {
-		stubFor(post(urlEqualTo("/"))
-				.withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildCharsetParametersSet(ISO_8859_1)));
-	}
-
-	@Test
-	public void iso88591CharsetResponse() throws BonitaException, UnsupportedEncodingException {
-		stubFor(post(urlEqualTo("/"))
-				.withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
-				.willReturn(aResponse().withHeader(WM_CONTENT_TYPE, PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1)
-						.withBody(new String("le text reçu a été encodé en ISO-8859-1").getBytes(ISO_8859_1))
-						.withStatus(HttpStatus.SC_OK)));
-
-		Map<String, Object> output = executeConnector(buildCharsetParametersSet(ISO_8859_1));
-		assertEquals("le text reçu a été encodé en ISO-8859-1",
-				output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
-	}
-
-	@Test
-	public void useISO88591CharsetWhenNoContentType() throws BonitaException, UnsupportedEncodingException {
-		stubFor(post(urlEqualTo("/"))
-				.withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
-				.willReturn(aResponse().withBody(new String("le text reçu n'a pas de header").getBytes(ISO_8859_1))
-						.withStatus(HttpStatus.SC_OK)));
-
-		Map<String, Object> output = executeConnector(buildCharsetParametersSet(ISO_8859_1));
-		assertEquals("le text reçu n'a pas de header", output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
-	}
-
-	@Test
-	public void useDefaultCharsetWhenNoContentTypeAndFallbackPropertyIsSet()
-			throws BonitaException, UnsupportedEncodingException {
-		System.setProperty(RESTConnector.DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY, "true");
-		stubFor(post(urlEqualTo("/"))
-				.withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
-				.willReturn(aResponse().withBody(new String("le text reçu a été encodé avec le charset par default")
-						.getBytes(Charset.defaultCharset())).withStatus(HttpStatus.SC_OK)));
-
-		Map<String, Object> output = executeConnector(buildCharsetParametersSet(ISO_8859_1));
-		assertEquals("le text reçu a été encodé avec le charset par default",
-				output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
-	}
-
-	@Test
-	public void utf8CharsetResponse() throws BonitaException, UnsupportedEncodingException {
-		stubFor(post(urlEqualTo("/")).withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8))
-				.willReturn(aResponse().withHeader(WM_CONTENT_TYPE, PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8)
-						.withBody(new String("le text reçu a été encodé en UTF8").getBytes(UTF8))
-						.withStatus(HttpStatus.SC_OK)));
-
-		Map<String, Object> output = executeConnector(buildCharsetParametersSet(UTF8));
-		assertEquals("le text reçu a été encodé en UTF8", output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
-	}
-
-	/**
-	 * Test the US ASCII charset
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void usASCIICharset() throws BonitaException {
-		stubFor(post(urlEqualTo("/"))
-				.withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + US_ASCII))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildCharsetParametersSet(US_ASCII)));
-	}
-
-	/**
-	 * Test the FAKE charset
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void fakeCharset() throws BonitaException {
-		thrown.expect(BonitaException.class);
-		thrown.expectMessage("java.nio.charset.UnsupportedCharsetException: FAKE-CHARSET");
-
-		checkResultIsPresent(executeConnector(buildCharsetParametersSet(CHARSET_ERROR)));
-	}
-
-	/**
-	 * Test one value cookie
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void oneValueCookie() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).withHeader(WM_COOKIES, equalTo(generateCookieSet(ONE_COOKIES)))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildCookieParametersSet(ONE_COOKIES)));
-	}
-
-	/**
-	 * Test two values cookie
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void twoValuesCookie() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).withHeader(WM_COOKIES, equalTo(generateCookieSet(TWO_COOKIES)))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildCookieParametersSet(TWO_COOKIES)));
-	}
-
-	/**
-	 * Generate the cookies string
-	 * 
-	 * @param cookies The cookies values
-	 * @return The cookie string
-	 */
-	private String generateCookieSet(final List<List<String>> cookies) {
-		final StringBuffer strBuffer = new StringBuffer();
-
-		if (!cookies.isEmpty()) {
-			strBuffer.append(cookies.get(0).get(0) + "=" + cookies.get(0).get(1));
-		}
-		for (int i = 1; i < cookies.size(); i++) {
-			strBuffer.append("; " + cookies.get(i).get(0) + "=" + cookies.get(i).get(1));
-		}
-
-		return strBuffer.toString();
-	}
-
-	/**
-	 * Test one value header
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void oneValueHeader() throws BonitaException {
-		final MappingBuilder mb = get(urlEqualTo("/"));
-		for (int j = 0; j < ONE_HEADERS.size(); j++) {
-			mb.withHeader(ONE_HEADERS.get(j).get(0), equalTo(ONE_HEADERS.get(j).get(1)));
-		}
-		stubFor(mb.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildHeaderParametersSet(ONE_HEADERS)));
-	}
-
-	/**
-	 * Test two values header
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void twoValuesHeader() throws BonitaException {
-		final MappingBuilder mb = get(urlEqualTo("/"));
-		for (int j = 0; j < TWO_HEADERS.size(); j++) {
-			mb.withHeader(TWO_HEADERS.get(j).get(0), equalTo(TWO_HEADERS.get(j).get(1)));
-		}
-		stubFor(mb.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildHeaderParametersSet(TWO_HEADERS)));
-	}
-
-	/**
-	 * Test empty body
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void emptyBody() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withRequestBody(equalTo(EMPTY))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildBodyParametersSet(EMPTY)));
-	}
-
-	/**
-	 * Test not empty body
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void notEmptyBody() throws BonitaException {
-		stubFor(post(urlEqualTo("/")).withRequestBody(equalTo(FULL))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(executeConnector(buildBodyParametersSet(FULL)));
-	}
-
-	/**
-	 * Test the basic auth with username and password
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void basicAuthWithUsernameAndPassword() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).withHeader(WM_AUTHORIZATION, containing(BASIC_RULE))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-		checkResultIsPresent(
-				executeConnector(buildBasicAuthorizationParametersSet(USERNAME, PASSWORD, EMPTY, EMPTY, Boolean.TRUE)));
-	}
-
-	/**
-	 * Test the basic auth with username password and localhost
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void basicAuthWithUsernamePasswordAndLocalhost() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).withHeader(WM_AUTHORIZATION, containing(BASIC_RULE))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(
-				executeConnector(buildBasicAuthorizationParametersSet(USERNAME, PASSWORD, HOST, EMPTY, Boolean.TRUE)));
-	}
-
-	/**
-	 * Test the basic auth with username password and realm
-	 * 
-	 * @throws BonitaException      exception
-	 * @throws InterruptedException exception
-	 */
-	@Test
-	public void basicAuthWithUsernamePasswordAndRealm() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).withHeader(WM_AUTHORIZATION, containing(BASIC_RULE))
-				.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-		checkResultIsPresent(
-				executeConnector(buildBasicAuthorizationParametersSet(USERNAME, PASSWORD, EMPTY, REALM, Boolean.TRUE)));
-	}
-
-	/**
-	 * Test no service available
-	 * 
-	 * @throws InterruptedException exception
-	 * @throws BonitaException
-	 */
-	@Test
-	public void noServiceAvailable() throws BonitaException {
-		Map<String, Object> output = executeConnector(buildMethodParametersSet(GET));
-		assertEquals(404, output.get(RESTConnector.STATUS_CODE_OUTPUT_PARAMETER));
-	}
-
-	/**
-	 * Test unreachable URL
-	 * 
-	 * @throws InterruptedException exception
-	 * @throws BonitaException
-	 */
-	@Test
-	public void unreachableURL() throws BonitaException {
-		thrown.expect(BonitaException.class);
-		thrown.expectCause(isA(UnknownHostException.class));
-
-		executeConnector(buildURLParametersSet(FAKE_URL));
-	}
-
-	/**
-	 * Test unreachable port
-	 * 
-	 * @throws InterruptedException exception
-	 * @throws BonitaException
-	 */
-	@Test
-	public void unreachablePort() throws BonitaException {
-		final String fakePort = "666";
-		thrown.expect(BonitaException.class);
-		thrown.expectMessage("org.apache.http.conn.HttpHostConnectException");
-		thrown.expectMessage(fakePort);
-
-		executeConnector(buildPortParametersSet(fakePort));
-	}
-
-	@Test
-	public void should_remove_empty_lines_from_input_tables() throws Exception {
-		final RESTConnector restConnector = new RESTConnector();
-		final Map<String, Object> parameters = Maps.newHashMap();
-
-		final List<List<?>> cookies = new ArrayList<>();
-		cookies.add(newArrayList("key1", "value"));
-		cookies.add(newArrayList("", ""));
-		cookies.add(newArrayList(null, null));
-		cookies.add(newArrayList());
-		cookies.add(null);
-		parameters.put(RESTConnector.URLCOOKIES_INPUT_PARAMETER, cookies);
-		restConnector.setInputParameters(parameters);
-
-		final List urlCookies = restConnector.getUrlCookies();
-		assertTrue(urlCookies.size() == 1);
-	}
-
-	@Test
-	public void should_set_empty_values_in_output_parameters_map_if_response_body_is_null() throws BonitaException {
-		stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_NO_CONTENT)));
-		Map<String, Object> outputs = executeConnector(buildMethodParametersSet(GET));
-
-		Object bodyAsObject = outputs.get("bodyAsObject");
-		assertTrue(bodyAsObject instanceof Map);
-		assertTrue(((Map) bodyAsObject).isEmpty());
-
-		Object bodyAsString = outputs.get("bodyAsString");
-		assertTrue(bodyAsString instanceof String);
-		assertTrue(((String) bodyAsString).isEmpty());
-	}
-
-	@Test
-	public void should_set_a_default_trust_certificate_strategy_value() throws Exception {
-		Map<String, Object> parameters = buildBodyParametersSet("");
-		RESTConnector restConnector = new RESTConnector();
-		parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, null);
-		restConnector.setInputParameters(parameters);
-		restConnector.validateInputParameters();
-		assertThat(restConnector.getTrustCertificateStrategy()).isEqualTo(TrustCertificateStrategy.DEFAULT);
-		
-		parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, " ");
-		restConnector.setInputParameters(parameters);
-		restConnector.validateInputParameters();
-		assertThat(restConnector.getTrustCertificateStrategy()).isEqualTo(TrustCertificateStrategy.DEFAULT);
-	}
-	
-	@Test
-	public void should_return_trust_certificate_strategy_value() throws Exception {
-		Map<String, Object> parameters = buildBodyParametersSet("");
-		RESTConnector restConnector = new RESTConnector();
-		parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, TrustCertificateStrategy.TRUST_ALL.name());
-		restConnector.setInputParameters(parameters);
-		restConnector.validateInputParameters();
-		assertThat(restConnector.getTrustCertificateStrategy()).isEqualTo(TrustCertificateStrategy.TRUST_ALL);
-	}
-	
-	@Test
-	public void should_throw_validation_exception_for_unknown_trust_certificate_strategy_input() throws Exception {
-		Map<String, Object> parameters = buildBodyParametersSet("");
-		parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, "unknownStrategy");
-		RESTConnector restConnector = new RESTConnector();
-		restConnector.setInputParameters(parameters);
-		assertThatThrownBy(() -> restConnector.validateInputParameters())
-				.isInstanceOf(ConnectorValidationException.class)
-				.hasMessage("'unknownStrategy' option is invalid for trust_strategy. Only one of [DEFAULT, TRUST_SELF_SIGNED, TRUST_ALL] is supported.");
-	}
-	
-	@Test
-    public void should_support_url_encoded_content_type() throws Exception {
-	    LinkedHashMap requestBody = new LinkedHashMap();
-	    requestBody.put("name","value1");
-	    requestBody.put("token","value2");
-        stubFor(post(urlEqualTo("/"))
-	            .withHeader(WM_CONTENT_TYPE, equalTo(ContentType.APPLICATION_FORM_URLENCODED.getMimeType() + "; " + WM_CHARSET + "=" + UTF8))
-                .withRequestBody(containing(WireMockUtil.toFormUrlEncoded(requestBody)))
-	            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
-
-        Map<String, Object> parameters = buildContentTypeParametersSet(ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
-        parameters.put(AbstractRESTConnectorImpl.BODY_INPUT_PARAMETER, "name=value1&token=value2");
-        checkResultIsPresent(executeConnector(parameters));
+  private static final int NB_OUTPUTS = 5;
+
+  // WireMock
+  /** All HTTP static strings used by WireMock to do tests */
+  private static final String WM_CONTENT_TYPE = "Content-Type";
+
+  private static final String WM_CHARSET = "charset";
+  private static final String WM_COOKIES = "Cookie";
+  private static final String WM_AUTHORIZATION = "Authorization";
+
+  // METHODS
+  /** All the tested method values */
+  private static final String GET = "GET";
+
+  private static final String POST = "POST";
+  private static final String PUT = "PUT";
+  private static final String DELETE = "DELETE";
+  private static final String METHOD_ERROR = "FAKE_METHOD";
+
+  // CONTENT_TYPES
+  /** All the tested content type values */
+  private static final String PLAIN_TEXT = "text/plain";
+
+  private static final String JSON = "application/json";
+  private static final String CONTENT_TYPE_ERROR = "fakecontenttype";
+
+  // CHARSETS
+  /** All the tested charset values */
+  private static final String UTF8 = "UTF-8";
+
+  private static final String ISO_8859_1 = "ISO-8859-1";
+  private static final String US_ASCII = "US-ASCII";
+  private static final String CHARSET_ERROR = "FAKE-CHARSET";
+
+  // COOKIES
+  /** All the tested cookies values */
+  private static final List<List<String>> ONE_COOKIES = new ArrayList<>();
+
+  private static final List<List<String>> TWO_COOKIES = new ArrayList<>();
+  private static final List<List<String>> COOKIES_ERROR = new ArrayList<>();
+
+  // HEADERS
+  /** All the tested headers values */
+  private static final List<List<String>> ONE_HEADERS = new ArrayList<>();
+
+  private static final List<List<String>> TWO_HEADERS = new ArrayList<>();
+  private static final List<List<String>> HEADERS_ERROR = new ArrayList<>();
+
+  // BODYS
+  /** All the tested bodies values */
+  private static final String EMPTY = "";
+
+  private static final String FULL = "there is something inside";
+
+  // SSL VERIFIERS
+  /** All the tested SSL verifier values */
+  private static final String STRICT = "Strict";
+
+  // AUTHORIZATIONS
+  /** All the tested authorization values */
+  private static final String BASIC_RULE = "Basic";
+
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+  private static final String REALM = "realm";
+  private static final String HOST = "localhost";
+  // private static final String TOKEN = "token";
+
+  // OTHER ERRORS
+  /** All the tested errors */
+  private static final String FAKE_URL = "fakeURL";
+
+  /** Used to assert Exceptions */
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  /** Initialize the tested values */
+  @BeforeClass
+  public static final void initValues() {
+    final List<String> cookie1 = new ArrayList<>();
+    cookie1.add("cookie1name");
+    cookie1.add("cookie1value");
+    ONE_COOKIES.add(cookie1);
+
+    final List<String> cookie2 = new ArrayList<>();
+    cookie2.add("cookie2name");
+    cookie2.add("cookie2value");
+    TWO_COOKIES.add(cookie1);
+    TWO_COOKIES.add(cookie2);
+
+    final List<String> cookie3 = new ArrayList<>();
+    cookie3.add("cookie3name");
+    cookie3.add("cookie3value");
+    cookie3.add("cookie3extrat");
+    final List<String> cookie4 = new ArrayList<>();
+    cookie4.add("cookie4nameonly");
+    COOKIES_ERROR.add(cookie1);
+    COOKIES_ERROR.add(cookie2);
+    COOKIES_ERROR.add(cookie3);
+    COOKIES_ERROR.add(cookie4);
+
+    final List<String> header1 = new ArrayList<>();
+    header1.add("header1name");
+    header1.add("header1value");
+    ONE_HEADERS.add(header1);
+
+    final List<String> header2 = new ArrayList<>();
+    header2.add("header2name");
+    header2.add("header2value");
+    TWO_HEADERS.add(header1);
+    TWO_HEADERS.add(header2);
+
+    final List<String> header3 = new ArrayList<>();
+    header3.add("header3name");
+    header3.add("header3value");
+    header3.add("header3extrat");
+    final List<String> header4 = new ArrayList<>();
+    header4.add("header4nameonly");
+    HEADERS_ERROR.add(header1);
+    HEADERS_ERROR.add(header2);
+    HEADERS_ERROR.add(header3);
+    HEADERS_ERROR.add(header4);
+  }
+
+  @After
+  public void resetSystemProperies() throws Exception {
+    System.setProperty(RESTConnector.DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY, "");
+  }
+
+  /**
+   * Build a request parameters set based on the given arguments
+   *
+   * @param url URL
+   * @param port Port
+   * @param method Method
+   * @param contentType Content type
+   * @param charset Charset
+   * @param cookies Cookies
+   * @param headers Headers
+   * @param body Body content
+   * @param redirect Is the redirection to be used
+   * @param ignoreBody Does the response body is ignored
+   * @param trust Trust self certificate
+   * @param sslVerifier SSL Verifier
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildParametersSet(
+      final String url,
+      final String port,
+      final String method,
+      final String contentType,
+      final String charset,
+      final List<List<String>> cookies,
+      final List<List<String>> headers,
+      final String body,
+      final Boolean redirect,
+      final Boolean ignoreBody,
+      final TrustCertificateStrategy trustCertificateStrategy,
+      final String sslVerifier) {
+    final Map<String, Object> parametersSet = new HashMap<>();
+    if (url == null && port == null) {
+      parametersSet.put(
+          AbstractRESTConnectorImpl.URL_INPUT_PARAMETER,
+          "http://" + LOCALHOST + ":" + wireMockServer.port() + "/");
+    } else if (url != null && port == null) {
+      parametersSet.put(
+          AbstractRESTConnectorImpl.URL_INPUT_PARAMETER,
+          "http://" + url + ":" + wireMockServer.port() + "/");
+    } else if (url == null && port != null) {
+      parametersSet.put(
+          AbstractRESTConnectorImpl.URL_INPUT_PARAMETER, "http://" + LOCALHOST + ":" + port + "/");
+    } else {
+      parametersSet.put(
+          AbstractRESTConnectorImpl.URL_INPUT_PARAMETER, "http://" + url + ":" + port + "/");
+    }
+    parametersSet.put(METHOD_INPUT_PARAMETER, method);
+    parametersSet.put(AbstractRESTConnectorImpl.CONTENTTYPE_INPUT_PARAMETER, contentType);
+    parametersSet.put(AbstractRESTConnectorImpl.CHARSET_INPUT_PARAMETER, charset);
+    parametersSet.put(AbstractRESTConnectorImpl.URLCOOKIES_INPUT_PARAMETER, cookies);
+    parametersSet.put(AbstractRESTConnectorImpl.URLHEADERS_INPUT_PARAMETER, headers);
+    parametersSet.put(BODY_INPUT_PARAMETER, body);
+    parametersSet.put(AbstractRESTConnectorImpl.DO_NOT_FOLLOW_REDIRECT_INPUT_PARAMETER, redirect);
+    parametersSet.put(AbstractRESTConnectorImpl.IGNORE_BODY_INPUT_PARAMETER, ignoreBody);
+    parametersSet.put(
+        AbstractRESTConnectorImpl.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER,
+        trustCertificateStrategy.name());
+    parametersSet.put(AbstractRESTConnectorImpl.HOSTNAME_VERIFIER_INPUT_PARAMETER, sslVerifier);
+    return parametersSet;
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific URL
+   *
+   * @param url URL
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildURLParametersSet(final String url) {
+    return buildParametersSet(
+        url,
+        null,
+        POST,
+        PLAIN_TEXT,
+        UTF8,
+        ONE_COOKIES,
+        ONE_HEADERS,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific port
+   *
+   * @param port Port
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildPortParametersSet(final String port) {
+    return buildParametersSet(
+        null,
+        port,
+        POST,
+        PLAIN_TEXT,
+        UTF8,
+        ONE_COOKIES,
+        ONE_HEADERS,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific Method
+   *
+   * @param method Method
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildMethodParametersSet(final String method) {
+    return buildParametersSet(
+        null,
+        null,
+        method,
+        PLAIN_TEXT,
+        UTF8,
+        ONE_COOKIES,
+        ONE_HEADERS,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific Content Type
+   *
+   * @param contentType Content Type
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildContentTypeParametersSet(final String contentType) {
+    return buildParametersSet(
+        null,
+        null,
+        POST,
+        contentType,
+        UTF8,
+        ONE_COOKIES,
+        ONE_HEADERS,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific Charset
+   *
+   * @param charset Charset
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildCharsetParametersSet(final String charset) {
+    return buildParametersSet(
+        null,
+        null,
+        POST,
+        PLAIN_TEXT,
+        charset,
+        ONE_COOKIES,
+        ONE_HEADERS,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific Cookies
+   *
+   * @param cookies Cookies
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildCookieParametersSet(final List<List<String>> cookies) {
+    return buildParametersSet(
+        null,
+        null,
+        GET,
+        PLAIN_TEXT,
+        UTF8,
+        cookies,
+        ONE_HEADERS,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific headers
+   *
+   * @param headers Headers
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildHeaderParametersSet(final List<List<String>> headers) {
+    return buildParametersSet(
+        null,
+        null,
+        GET,
+        PLAIN_TEXT,
+        UTF8,
+        ONE_COOKIES,
+        headers,
+        EMPTY,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific body content
+   *
+   * @param body Body content
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildBodyParametersSet(final String body) {
+    return buildParametersSet(
+        null,
+        null,
+        POST,
+        PLAIN_TEXT,
+        UTF8,
+        ONE_COOKIES,
+        ONE_HEADERS,
+        body,
+        Boolean.FALSE,
+        Boolean.FALSE,
+        TrustCertificateStrategy.DEFAULT,
+        STRICT);
+  }
+
+  /**
+   * Build a request parameters set in order to test a specific Basic Authorization
+   *
+   * @param username Username
+   * @param password Password
+   * @param host Host
+   * @param realm Realm
+   * @param preemptive Preemptive
+   * @return The set of parameters
+   */
+  private Map<String, Object> buildBasicAuthorizationParametersSet(
+      final String username,
+      final String password,
+      final String host,
+      final String realm,
+      final Boolean preemptive) {
+    final Map<String, Object> parametersSet =
+        buildParametersSet(
+            null,
+            null,
+            GET,
+            PLAIN_TEXT,
+            UTF8,
+            ONE_COOKIES,
+            ONE_HEADERS,
+            EMPTY,
+            Boolean.FALSE,
+            Boolean.FALSE,
+            TrustCertificateStrategy.DEFAULT,
+            STRICT);
+
+    parametersSet.put(
+        AbstractRESTConnectorImpl.AUTH_TYPE_PARAMETER, AuthorizationType.BASIC.name());
+    parametersSet.put(AbstractRESTConnectorImpl.AUTH_USERNAME_INPUT_PARAMETER, username);
+    parametersSet.put(AbstractRESTConnectorImpl.AUTH_PASSWORD_INPUT_PARAMETER, password);
+    parametersSet.put(AbstractRESTConnectorImpl.AUTH_HOST_INPUT_PARAMETER, host);
+    parametersSet.put(AbstractRESTConnectorImpl.AUTH_REALM_INPUT_PARAMETER, realm);
+    parametersSet.put(AbstractRESTConnectorImpl.AUTH_PREEMPTIVE_INPUT_PARAMETER, preemptive);
+
+    return parametersSet;
+  }
+
+  /**
+   * Execute a connector call
+   *
+   * @param parameters The parameters of the connector call
+   * @return The outputs of the connector
+   * @throws BonitaException exception
+   */
+  private Map<String, Object> executeConnector(final Map<String, Object> parameters)
+      throws BonitaException {
+    final RESTConnector rest = new RESTConnector();
+    rest.setExecutionContext(getEngineExecutionContext());
+    rest.setAPIAccessor(getApiAccessor());
+    rest.setInputParameters(parameters);
+    rest.validateInputParameters();
+    return rest.execute();
+  }
+
+  /**
+   * Test the GET method
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void getMethod() throws BonitaException {
+    stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildMethodParametersSet(GET)));
+  }
+
+  /**
+   * Test the POST method
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void postMethod() throws BonitaException {
+    stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildMethodParametersSet(POST)));
+  }
+
+  /**
+   * Test the PUT method
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void putMethod() throws BonitaException {
+    stubFor(put(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildMethodParametersSet(PUT)));
+  }
+
+  /**
+   * Test the DELETE method
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void deleteMethod() throws BonitaException {
+    stubFor(delete(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildMethodParametersSet(DELETE)));
+  }
+
+  /**
+   * Test the FAKE method
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void fakeMethod() throws BonitaException {
+    thrown.expect(BonitaException.class);
+    thrown.expectMessage(
+        "java.lang.IllegalArgumentException: No enum constant org.bonitasoft.connectors.rest.model.HTTPMethod.FAKE_METHOD");
+
+    checkResultIsPresent(executeConnector(buildMethodParametersSet(METHOD_ERROR)));
+  }
+
+  /**
+   * Test the plain text content type
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void plainTextContentType() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildContentTypeParametersSet(PLAIN_TEXT)));
+  }
+
+  /**
+   * Test the json content type
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void should_retrieve_response_as_a_Map_jsonContentType() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("{ \"name\":\"Romain\" }")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Map<String, Object> bodyAsMap =
+        (Map<String, Object>)
+            outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsMap);
+    assertEquals(bodyAsMap.get("name"), "Romain");
+  }
+
+  /**
+   * Test the json content type with wrong content
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void should_not_raise_exception_on_json_parsing_error() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("{ this is not valid json ! }")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Map<String, Object> bodyAsMap =
+        (Map<String, Object>)
+            outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsMap);
+    assertEquals(bodyAsMap.size(), 0);
+  }
+
+  /**
+   * Test the json simple string value
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void json_simple_string_value_should_return_string_object() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("\"this is a string\"")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Object bodyAsObject =
+        outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsObject);
+    final String bodyAsString = (String) bodyAsObject;
+    assertEquals(bodyAsString, "this is a string");
+  }
+
+  /**
+   * Test the json simple numeric value
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void json_simple_numeric_value_should_return_number_object() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("123.45")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Object bodyAsObject =
+        outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsObject);
+    final Number bodyAsNumber = (Number) bodyAsObject;
+    assertEquals(bodyAsNumber, 123.45);
+  }
+
+  /**
+   * Test the json simple boolean value
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void json_simple_boolean_value_should_return_boolean_object() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("true")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Object bodyAsObject =
+        outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsObject);
+    final Boolean bodyAsBoolean = (Boolean) bodyAsObject;
+    assertEquals(bodyAsBoolean, true);
+  }
+
+  /**
+   * Test the json simple date value
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void json_simple_date_value_should_return_iso8601_date_string() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("\"2012-04-23T18:25:43+02:00\"")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Object bodyAsObject =
+        outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsObject);
+    final Instant bodyAsInstant = OffsetDateTime.parse((String) bodyAsObject).toInstant();
+    assertEquals(
+        bodyAsInstant,
+        OffsetDateTime.of(2012, 4, 23, 18, 25, 43, 0, ZoneOffset.ofHours(2)).toInstant());
+  }
+
+  /**
+   * Test the json simple null value
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void json_simple_null_value_should_return_null() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("null")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Object bodyAsObject =
+        outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNull(bodyAsObject);
+  }
+
+  @Test
+  public void should_retrieve_response_as_a_List_of_Map__jsonContentType() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("[{ \"name\":\"Romain\" }]")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final Object bodyAsMap = outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsMap);
+    assertEquals(((Map<String, Object>) ((List) bodyAsMap).get(0)).get("name"), "Romain");
+  }
+
+  @Test
+  public void should_retrieve_response_as_a_List_of_string() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("[\"abc\", \"def\"]")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    final Map<String, Object> outputs = executeConnector(buildContentTypeParametersSet(JSON));
+    checkResultIsPresent(outputs);
+    final List<String> bodyAsList =
+        (List<String>) outputs.get(AbstractRESTConnectorImpl.BODY_AS_OBJECT_OUTPUT_PARAMETER);
+    assertNotNull(bodyAsList);
+    assertEquals(bodyAsList.get(0), "abc");
+    assertEquals(bodyAsList.get(1), "def");
+  }
+
+  @Test
+  public void should_close_connection_when_delay_is_more_than_socket_timeout()
+      throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(JSON + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withFixedDelay(1000)
+                    .withStatus(HttpStatus.SC_OK)
+                    .withBody("")
+                    .withHeader(WM_CONTENT_TYPE, JSON)));
+
+    thrown.expect(ConnectorException.class);
+    Map<String, Object> parameters = buildContentTypeParametersSet(JSON);
+    parameters.put("socket_timeout_ms", 50);
+    executeConnector(parameters);
+  }
+
+  @Test
+  public void should_have_default_timeout() {
+    assertTrue(new RESTConnector().getSocketTimeoutMs() > 0);
+    assertTrue(new RESTConnector().getConnectionTimeoutMs() > 0);
+  }
+
+  /**
+   * Test the fake content type
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void fakeContentType() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(
+                WM_CONTENT_TYPE, equalTo(CONTENT_TYPE_ERROR + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildContentTypeParametersSet(CONTENT_TYPE_ERROR)));
+  }
+
+  /**
+   * Test the UTF8 charset
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void utf8Charset() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildCharsetParametersSet(UTF8)));
+  }
+
+  /**
+   * Test the ISO-8859-1 charset
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void iso88591CharsetRequest() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildCharsetParametersSet(ISO_8859_1)));
+  }
+
+  @Test
+  public void iso88591CharsetResponse() throws BonitaException, UnsupportedEncodingException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
+            .willReturn(
+                aResponse()
+                    .withHeader(WM_CONTENT_TYPE, PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1)
+                    .withBody(
+                        new String("le text reçu a été encodé en ISO-8859-1").getBytes(ISO_8859_1))
+                    .withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> output = executeConnector(buildCharsetParametersSet(ISO_8859_1));
+    assertEquals(
+        "le text reçu a été encodé en ISO-8859-1",
+        output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
+  }
+
+  @Test
+  public void useISO88591CharsetWhenNoContentType()
+      throws BonitaException, UnsupportedEncodingException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
+            .willReturn(
+                aResponse()
+                    .withBody(new String("le text reçu n'a pas de header").getBytes(ISO_8859_1))
+                    .withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> output = executeConnector(buildCharsetParametersSet(ISO_8859_1));
+    assertEquals(
+        "le text reçu n'a pas de header",
+        output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
+  }
+
+  @Test
+  public void useDefaultCharsetWhenNoContentTypeAndFallbackPropertyIsSet()
+      throws BonitaException, UnsupportedEncodingException {
+    System.setProperty(RESTConnector.DEFAULT_JVM_CHARSET_FALLBACK_PROPERTY, "true");
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + ISO_8859_1))
+            .willReturn(
+                aResponse()
+                    .withBody(
+                        new String("le text reçu a été encodé avec le charset par default")
+                            .getBytes(Charset.defaultCharset()))
+                    .withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> output = executeConnector(buildCharsetParametersSet(ISO_8859_1));
+    assertEquals(
+        "le text reçu a été encodé avec le charset par default",
+        output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
+  }
+
+  @Test
+  public void utf8CharsetResponse() throws BonitaException, UnsupportedEncodingException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8))
+            .willReturn(
+                aResponse()
+                    .withHeader(WM_CONTENT_TYPE, PLAIN_TEXT + "; " + WM_CHARSET + "=" + UTF8)
+                    .withBody(new String("le text reçu a été encodé en UTF8").getBytes(UTF8))
+                    .withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> output = executeConnector(buildCharsetParametersSet(UTF8));
+    assertEquals(
+        "le text reçu a été encodé en UTF8",
+        output.get(RESTConnector.BODY_AS_STRING_OUTPUT_PARAMETER));
+  }
+
+  /**
+   * Test the US ASCII charset
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void usASCIICharset() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(WM_CONTENT_TYPE, equalTo(PLAIN_TEXT + "; " + WM_CHARSET + "=" + US_ASCII))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildCharsetParametersSet(US_ASCII)));
+  }
+
+  /**
+   * Test the FAKE charset
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void fakeCharset() throws BonitaException {
+    thrown.expect(BonitaException.class);
+    thrown.expectMessage("java.nio.charset.UnsupportedCharsetException: FAKE-CHARSET");
+
+    checkResultIsPresent(executeConnector(buildCharsetParametersSet(CHARSET_ERROR)));
+  }
+
+  /**
+   * Test one value cookie
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void oneValueCookie() throws BonitaException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .withHeader(WM_COOKIES, equalTo(generateCookieSet(ONE_COOKIES)))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildCookieParametersSet(ONE_COOKIES)));
+  }
+
+  /**
+   * Test two values cookie
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void twoValuesCookie() throws BonitaException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .withHeader(WM_COOKIES, equalTo(generateCookieSet(TWO_COOKIES)))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildCookieParametersSet(TWO_COOKIES)));
+  }
+
+  /**
+   * Generate the cookies string
+   *
+   * @param cookies The cookies values
+   * @return The cookie string
+   */
+  private String generateCookieSet(final List<List<String>> cookies) {
+    final StringBuffer strBuffer = new StringBuffer();
+
+    if (!cookies.isEmpty()) {
+      strBuffer.append(cookies.get(0).get(0) + "=" + cookies.get(0).get(1));
+    }
+    for (int i = 1; i < cookies.size(); i++) {
+      strBuffer.append("; " + cookies.get(i).get(0) + "=" + cookies.get(i).get(1));
     }
 
-	/**
-	 * Generic test: should return OK STATUS as the WireMock stub is set each time
-	 * for the good request shape
-	 * 
-	 * @param outputs The result of the request
-	 */
-	private void checkResultIsPresent(final Map<String, Object> outputs) {
-		checkResult(outputs, HttpStatus.SC_OK);
-	}
+    return strBuffer.toString();
+  }
 
-	/**
-	 * Generic test: should return OK STATUS as the WireMock stub is set each time
-	 * for the good request shape
-	 * 
-	 * @param outputs    The result of the request
-	 * @param httpStatus HTTP Status to be found as a result
-	 */
-	private void checkResult(final Map<String, Object> outputs, final int httpStatus) {
-		assertEquals(NB_OUTPUTS, outputs.size());
-		assertNotNull(outputs.get(AbstractRESTConnectorImpl.STATUS_CODE_OUTPUT_PARAMETER));
-		final Object statusCode = outputs.get(AbstractRESTConnectorImpl.STATUS_CODE_OUTPUT_PARAMETER);
-		assertTrue(statusCode instanceof Integer);
-		final Integer restStatusCode = (Integer) statusCode;
-		assertEquals(httpStatus, restStatusCode.intValue());
-	}
-	
-	public static class WireMockUtil {
-	    public static String toFormUrlEncoded(LinkedHashMap<String, String> map) {
-	        if (map == null) {
-	            return "";
-	        }
-	        StringBuilder sb = new StringBuilder();
-	        Iterator<String> it = map.keySet().iterator();
-	        while (it.hasNext()) {
-	            String key = it.next();
-	            String value = map.get(key);
-	            appendFormUrlEncoded(key,value,sb);
-	            if (it.hasNext()) {
-	                sb.append('&');
-	            }
-	        }
-	        return sb.toString();
-	    }
+  /**
+   * Test one value header
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void oneValueHeader() throws BonitaException {
+    final MappingBuilder mb = get(urlEqualTo("/"));
+    for (int j = 0; j < ONE_HEADERS.size(); j++) {
+      mb.withHeader(ONE_HEADERS.get(j).get(0), equalTo(ONE_HEADERS.get(j).get(1)));
+    }
+    stubFor(mb.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
 
-	    public static String toFormUrlEncoded(String key, String value) {
-	        StringBuilder sb = new StringBuilder();
-	        appendFormUrlEncoded(key, value,sb);
-	        return sb.toString();
-	    }
+    checkResultIsPresent(executeConnector(buildHeaderParametersSet(ONE_HEADERS)));
+  }
 
-	    public static void appendFormUrlEncoded(String key, String value, StringBuilder sb) {
-	        sb.append(key).append('=');
-	        if (value != null) {
-	            sb.append(value);
-	        }
-	    }
-	}
+  /**
+   * Test two values header
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void twoValuesHeader() throws BonitaException {
+    final MappingBuilder mb = get(urlEqualTo("/"));
+    for (int j = 0; j < TWO_HEADERS.size(); j++) {
+      mb.withHeader(TWO_HEADERS.get(j).get(0), equalTo(TWO_HEADERS.get(j).get(1)));
+    }
+    stubFor(mb.willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildHeaderParametersSet(TWO_HEADERS)));
+  }
+
+  /**
+   * Test empty body
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void emptyBody() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withRequestBody(equalTo(EMPTY))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildBodyParametersSet(EMPTY)));
+  }
+
+  @Test
+  public void shouldPostWithByteArrayBody() throws BonitaException {
+    stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> parameters = buildBodyParametersSet(EMPTY);
+    parameters.put(METHOD_INPUT_PARAMETER, POST);
+    parameters.put(BODY_INPUT_PARAMETER, "content".getBytes());
+
+    Map<String, Object> outputs = executeConnector(parameters);
+
+    checkResultIsPresent(outputs);
+  }
+
+  @Test
+  public void shouldPutWithByteArrayBody() throws BonitaException {
+    stubFor(put(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> parameters = buildBodyParametersSet(EMPTY);
+    parameters.put(METHOD_INPUT_PARAMETER, PUT);
+    parameters.put(BODY_INPUT_PARAMETER, "content".getBytes());
+
+    Map<String, Object> outputs = executeConnector(parameters);
+
+    checkResultIsPresent(outputs);
+  }
+
+  /**
+   * Test not empty body
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void notEmptyBody() throws BonitaException {
+    stubFor(
+        post(urlEqualTo("/"))
+            .withRequestBody(equalTo(FULL))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(executeConnector(buildBodyParametersSet(FULL)));
+  }
+
+  /**
+   * Test the basic auth with username and password
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void basicAuthWithUsernameAndPassword() throws BonitaException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .withHeader(WM_AUTHORIZATION, containing(BASIC_RULE))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+    checkResultIsPresent(
+        executeConnector(
+            buildBasicAuthorizationParametersSet(USERNAME, PASSWORD, EMPTY, EMPTY, Boolean.TRUE)));
+  }
+
+  /**
+   * Test the basic auth with username password and localhost
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void basicAuthWithUsernamePasswordAndLocalhost() throws BonitaException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .withHeader(WM_AUTHORIZATION, containing(BASIC_RULE))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(
+        executeConnector(
+            buildBasicAuthorizationParametersSet(USERNAME, PASSWORD, HOST, EMPTY, Boolean.TRUE)));
+  }
+
+  /**
+   * Test the basic auth with username password and realm
+   *
+   * @throws BonitaException exception
+   * @throws InterruptedException exception
+   */
+  @Test
+  public void basicAuthWithUsernamePasswordAndRealm() throws BonitaException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .withHeader(WM_AUTHORIZATION, containing(BASIC_RULE))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    checkResultIsPresent(
+        executeConnector(
+            buildBasicAuthorizationParametersSet(USERNAME, PASSWORD, EMPTY, REALM, Boolean.TRUE)));
+  }
+
+  /**
+   * Test no service available
+   *
+   * @throws InterruptedException exception
+   * @throws BonitaException
+   */
+  @Test
+  public void noServiceAvailable() throws BonitaException {
+    Map<String, Object> output = executeConnector(buildMethodParametersSet(GET));
+    assertEquals(404, output.get(RESTConnector.STATUS_CODE_OUTPUT_PARAMETER));
+  }
+
+  /**
+   * Test unreachable URL
+   *
+   * @throws InterruptedException exception
+   * @throws BonitaException
+   */
+  @Test
+  public void unreachableURL() throws BonitaException {
+    thrown.expect(BonitaException.class);
+    thrown.expectCause(isA(UnknownHostException.class));
+
+    executeConnector(buildURLParametersSet(FAKE_URL));
+  }
+
+  /**
+   * Test unreachable port
+   *
+   * @throws InterruptedException exception
+   * @throws BonitaException
+   */
+  @Test
+  public void unreachablePort() throws BonitaException {
+    final String fakePort = "666";
+    thrown.expect(BonitaException.class);
+    thrown.expectMessage("org.apache.http.conn.HttpHostConnectException");
+    thrown.expectMessage(fakePort);
+
+    executeConnector(buildPortParametersSet(fakePort));
+  }
+
+  @Test
+  public void should_remove_empty_lines_from_input_tables() throws Exception {
+    final RESTConnector restConnector = new RESTConnector();
+    final Map<String, Object> parameters = Maps.newHashMap();
+
+    final List<List<?>> cookies = new ArrayList<>();
+    cookies.add(newArrayList("key1", "value"));
+    cookies.add(newArrayList("", ""));
+    cookies.add(newArrayList(null, null));
+    cookies.add(newArrayList());
+    cookies.add(null);
+    parameters.put(RESTConnector.URLCOOKIES_INPUT_PARAMETER, cookies);
+    restConnector.setInputParameters(parameters);
+
+    final List urlCookies = restConnector.getUrlCookies();
+    assertTrue(urlCookies.size() == 1);
+  }
+
+  @Test
+  public void should_set_empty_values_in_output_parameters_map_if_response_body_is_null()
+      throws BonitaException {
+    stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(HttpStatus.SC_NO_CONTENT)));
+    Map<String, Object> outputs = executeConnector(buildMethodParametersSet(GET));
+
+    Object bodyAsObject = outputs.get("bodyAsObject");
+    assertTrue(bodyAsObject instanceof Map);
+    assertTrue(((Map) bodyAsObject).isEmpty());
+
+    Object bodyAsString = outputs.get("bodyAsString");
+    assertTrue(bodyAsString instanceof String);
+    assertTrue(((String) bodyAsString).isEmpty());
+  }
+
+  @Test
+  public void should_set_a_default_trust_certificate_strategy_value() throws Exception {
+    Map<String, Object> parameters = buildBodyParametersSet("");
+    RESTConnector restConnector = new RESTConnector();
+    parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, null);
+    restConnector.setInputParameters(parameters);
+    restConnector.validateInputParameters();
+    assertThat(restConnector.getTrustCertificateStrategy())
+        .isEqualTo(TrustCertificateStrategy.DEFAULT);
+
+    parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, " ");
+    restConnector.setInputParameters(parameters);
+    restConnector.validateInputParameters();
+    assertThat(restConnector.getTrustCertificateStrategy())
+        .isEqualTo(TrustCertificateStrategy.DEFAULT);
+  }
+
+  @Test
+  public void should_return_trust_certificate_strategy_value() throws Exception {
+    Map<String, Object> parameters = buildBodyParametersSet("");
+    RESTConnector restConnector = new RESTConnector();
+    parameters.put(
+        RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER,
+        TrustCertificateStrategy.TRUST_ALL.name());
+    restConnector.setInputParameters(parameters);
+    restConnector.validateInputParameters();
+    assertThat(restConnector.getTrustCertificateStrategy())
+        .isEqualTo(TrustCertificateStrategy.TRUST_ALL);
+  }
+
+  @Test
+  public void should_throw_validation_exception_for_unknown_trust_certificate_strategy_input()
+      throws Exception {
+    Map<String, Object> parameters = buildBodyParametersSet("");
+    parameters.put(RESTConnector.TRUST_CERTIFICATE_STRATEGY_INPUT_PARAMETER, "unknownStrategy");
+    RESTConnector restConnector = new RESTConnector();
+    restConnector.setInputParameters(parameters);
+    assertThatThrownBy(() -> restConnector.validateInputParameters())
+        .isInstanceOf(ConnectorValidationException.class)
+        .hasMessage(
+            "'unknownStrategy' option is invalid for trust_strategy. Only one of [DEFAULT, TRUST_SELF_SIGNED, TRUST_ALL] is supported.");
+  }
+
+  @Test
+  public void should_support_url_encoded_content_type() throws Exception {
+    LinkedHashMap requestBody = new LinkedHashMap();
+    requestBody.put("name", "value1");
+    requestBody.put("token", "value2");
+    stubFor(
+        post(urlEqualTo("/"))
+            .withHeader(
+                WM_CONTENT_TYPE,
+                equalTo(
+                    ContentType.APPLICATION_FORM_URLENCODED.getMimeType()
+                        + "; "
+                        + WM_CHARSET
+                        + "="
+                        + UTF8))
+            .withRequestBody(containing(WireMockUtil.toFormUrlEncoded(requestBody)))
+            .willReturn(aResponse().withStatus(HttpStatus.SC_OK)));
+
+    Map<String, Object> parameters =
+        buildContentTypeParametersSet(ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+    parameters.put(BODY_INPUT_PARAMETER, "name=value1&token=value2");
+    checkResultIsPresent(executeConnector(parameters));
+  }
+
+  /**
+   * Generic test: should return OK STATUS as the WireMock stub is set each time for the good
+   * request shape
+   *
+   * @param outputs The result of the request
+   */
+  private void checkResultIsPresent(final Map<String, Object> outputs) {
+    checkResult(outputs, HttpStatus.SC_OK);
+  }
+
+  /**
+   * Generic test: should return OK STATUS as the WireMock stub is set each time for the good
+   * request shape
+   *
+   * @param outputs The result of the request
+   * @param httpStatus HTTP Status to be found as a result
+   */
+  private void checkResult(final Map<String, Object> outputs, final int httpStatus) {
+    assertEquals(NB_OUTPUTS, outputs.size());
+    assertNotNull(outputs.get(AbstractRESTConnectorImpl.STATUS_CODE_OUTPUT_PARAMETER));
+    final Object statusCode = outputs.get(AbstractRESTConnectorImpl.STATUS_CODE_OUTPUT_PARAMETER);
+    assertTrue(statusCode instanceof Integer);
+    final Integer restStatusCode = (Integer) statusCode;
+    assertEquals(httpStatus, restStatusCode.intValue());
+  }
+
+  public static class WireMockUtil {
+    public static String toFormUrlEncoded(LinkedHashMap<String, String> map) {
+      if (map == null) {
+        return "";
+      }
+      StringBuilder sb = new StringBuilder();
+      Iterator<String> it = map.keySet().iterator();
+      while (it.hasNext()) {
+        String key = it.next();
+        String value = map.get(key);
+        appendFormUrlEncoded(key, value, sb);
+        if (it.hasNext()) {
+          sb.append('&');
+        }
+      }
+      return sb.toString();
+    }
+
+    public static String toFormUrlEncoded(String key, String value) {
+      StringBuilder sb = new StringBuilder();
+      appendFormUrlEncoded(key, value, sb);
+      return sb.toString();
+    }
+
+    public static void appendFormUrlEncoded(String key, String value, StringBuilder sb) {
+      sb.append(key).append('=');
+      if (value != null) {
+        sb.append(value);
+      }
+    }
+  }
 }


### PR DESCRIPTION
feat(document): add support for binary body content

* update definition to 1.3.1
* change body param type from `String` to `Serializable`
* add support for document (Bonita version) using byte array as payload
* add `application/octet-stream` content type for PUT and POST
* add spotless maven plugin to fix formatting issues between IDEs
* fix gihub action in order to make then working on forked repo, skip steps with required secrets (SONAR)
* add maven cache support 