### PR TITLE
chore(actions): Replace deprecated ::set-output syntax on action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,7 @@ jobs:
         SONAR_IS_SET: ${{ secrets.SONAR_TOKEN }}
       run: |
         echo "Is Sonar Set: ${{ env.SONAR_IS_SET != '' }}"
-        echo "::set-output name=sonar-enable::${{ env.SONAR_IS_SET != '' }}"
-
+        echo "sonar-enable=${{ env.SONAR_IS_SET != '' }}" >> $GITHUB_OUTPUT
     - name: Run Sonar
       if: ${{ steps.is-sonar-set.outputs.sonar-enable == 'true' }}
       env:


### PR DESCRIPTION
On may, ::set-output name={name}::{value} will be EOL, we replaced it from echo "{name}={value}" >> $GITHUB_OUTPUT synthax