### PR TITLE
ci(publish): fix maven central publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,12 @@ name: Build
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ master ]
-
+    paths-ignore:
+      - '**/*.md'
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -33,7 +36,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         SONAR_TOKEN: ${{env.SONAR_TOKEN}}
-      run: ./mvnw -B clean verify sonar:sonar
+      run: ./mvnw -B -ntp clean verify sonar:sonar
 
     - name: Copy artifacts for staging
       run: |

--- a/README.MD
+++ b/README.MD
@@ -16,8 +16,11 @@ __Clone__ or __fork__ this repository, then at the root of the project run:
 
 In order to create a new release:
 - On the release branch, make sure to update the pom version (remove the -SNAPSHOT)
-- Run the action 'Create release', set the version to release as parameter
-- Update the `master` with the next SNAPSHOT version.
+- Run the [release](https://github.com/bonitasoft/bonita-connector-rest/actions/workflows/release.yml) action, set the version to release as parameter. The release will be published to [Maven Central](https://central.sonatype.com/artifact/org.bonitasoft.connectors/bonita-connector-uipath).
+- Update the `master` branch with the next SNAPSHOT version.
+
+Once this is done, update the [Bonita marketplace repository](https://github.com/bonitasoft/bonita-marketplace) with the new version of the connector.
+
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "bonita-connector-rest",
-  "comment": "This json file is required by the generate-changelog-action, do not remove it."
-}

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
 		<groovy.version>3.0.19</groovy.version>
 		<maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
-		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-		<maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
+        <central-maven-plugin.version>0.8.0</central-maven-plugin.version>
+        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 
 		<!-- Sonar -->
@@ -443,6 +443,10 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+            </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
The new plugin in charge of the publishing wasn't correctly configured.

Also
- improve the description of the release process and remove unused resources (changelog is now managed by GH releases)
- improve the build workflow

### Notes

The maven central plugin always run (not only on publish). When it runs, the following logs appear at the beginning of the build
```
[INFO] Inspecting build with total of 1 modules
[INFO] Installing Central Publishing features 
```