### PR TITLE
chore(pom): remove Terracotta repository declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,22 +493,6 @@
 		</profile>
 	</profiles>
 
-    <repositories>
-        <!-- Declare Terracotta repository to retrieve latest ehcache 2.x transitive artifacts
-        that are no longer available on Maven Central -->
-        <repository>
-            <id>terracotta</id>
-            <name>terracotta.org</name>
-            <url>https://repo.terracotta.org/maven2/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
 	<scm>
 		<developerConnection>
 			scm:git:git@github.com:bonitasoft/bonita-connector-rest.git</developerConnection>


### PR DESCRIPTION
## Summary
- Remove the Terracotta repository declaration from pom.xml, which was used to retrieve ehcache 2.x transitive artifacts no longer needed

## Test plan
- [x] Verify build passes without the Terracotta repository (`./mvnw clean verify`)